### PR TITLE
quick patch that allows a powershell's contents to be passed to run_powershell_script

### DIFF
--- a/lib/winrm/winrm_service.rb
+++ b/lib/winrm/winrm_service.rb
@@ -195,13 +195,12 @@ module WinRM
 
 
     # Run a Powershell script that resides on the local box.
-    # @param [String] script_file The string representing the path to a Powershell script or the the file contents themselves
+    # @param [IO] script_file an IO reference for reading the Powershell script or the actual file contents
     # @return [Hash] :stdout and :stderr
     def run_powershell_script(script_file)
-      # if a path was passed read the contents of the file in
-      if script_file =~ /^\/|.\:[\\\/]/
-        script = File.read(script_file)
-      end
+      # if an IO object is passed read it..otherwise 
+      # assume the contents of the file were passed
+      script = script_file.kind_of?(IO) ? script_file.read : script_file
 
       script = script.chars.to_a.join("\x00").chomp
       if(defined?(script.encode))


### PR DESCRIPTION
This is useful for the use case where powershell scripts are being generated in memory via something like ERB.
