### PR TITLE
Fix for `send_request': undefined method `content' for #<String:0x00000002acce78>

### DIFF
--- a/winrm.gemspec
+++ b/winrm.gemspec
@@ -24,10 +24,10 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = %w(README COPYING.txt)
 
   s.required_ruby_version	= '>= 1.9.0'
-  s.add_runtime_dependency  'gssapi', '>= 0.1.5'
-  s.add_runtime_dependency  'nokogiri'
-  s.add_runtime_dependency  'httpclient'
-  s.add_runtime_dependency  'rubyntlm'
-  s.add_runtime_dependency  'uuidtools'
-  s.add_runtime_dependency  'savon'
+  s.add_runtime_dependency  'gssapi', '~> 0.1.5'
+  s.add_runtime_dependency  'nokogiri', '~> 1.4.4'
+  s.add_runtime_dependency  'httpclient', '~> 2.1.7.2'
+  s.add_runtime_dependency  'rubyntlm', '~> 0.1.1'
+  s.add_runtime_dependency  'uuidtools', '~> 2.1.2'
+  s.add_runtime_dependency  'savon', '~> 0.9.1'
 end


### PR DESCRIPTION
There has been a minor version bump (now at 2.2.0.1) in the `httpclient` gem which is breaking this gem.  The fix is to install version 2.1.7.2 of the `httpclient` gem.

This can easily be avoided in the future by placing explicit versions on the gem's dependencies and 'boxing' them using the pessimistic operator ~> :
http://docs.rubygems.org/read/chapter/16#page74

This will stop API incompatibilities between minor version releases of dependent gems.
