### PR TITLE
don't load gssapi until it's needed

### DIFF
--- a/lib/winrm/soap_provider.rb
+++ b/lib/winrm/soap_provider.rb
@@ -21,7 +21,6 @@
 require 'httpclient'
 require 'savon/soap/xml'
 require 'uuidtools'
-require 'gssapi'
 require 'base64'
 require 'nokogiri'
 

--- a/lib/winrm/winrm_service.rb
+++ b/lib/winrm/winrm_service.rb
@@ -22,6 +22,7 @@ module WinRM
       @locale = DEFAULT_LOCALE
       case transport
       when :kerberos
+        require 'gssapi'
         # TODO: check fo keys and throw error if missing
         @xfer = HTTP::HttpGSSAPI.new(endpoint, opts[:realm], opts[:service], opts[:keytab], opts)
       when :plaintext


### PR DESCRIPTION
The gssapi/kerberos related auth logic is proving troublesome on some platforms (centos, darwin and windows):
https://github.com/zenchild/gssapi/issues/5

As `gssapi` isn't needed at all if you choose to use ssl/plaintext + basic this gem shouldn't be required until needed.  This pull request does just that!
