### PR TITLE
Powershell scripts need to be null terminated to run properly

### DIFF
--- a/lib/winrm/winrm_service.rb
+++ b/lib/winrm/winrm_service.rb
@@ -254,7 +254,7 @@ module WinRM
       script = script_file.kind_of?(IO) ? script_file.read : script_file
 
       script = script.chars.to_a.join("\x00").chomp
-      script << "\x00"
+      script << "\x00" unless script[-1].eql? "\x00"
       if(defined?(script.encode))
         script = script.encode('ASCII-8BIT')
         script = Base64.strict_encode64(script)


### PR DESCRIPTION
@zenchild - in working on some vagrant integration, I found that powershell scripts would not run properly in some cases. As it turns out, in addition to the encoded string needing to be joined on null characters, it also need to be terminated by a null character. I have tested on OSX and all works properly. 

Cheers,

Paul
