### PR TITLE
Loosen the dependency on the logger gem

### DIFF
--- a/winrm.gemspec
+++ b/winrm.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency  'rubyntlm', '~> 0.1.1'
   s.add_runtime_dependency  'uuidtools', '~> 2.1.2'
   s.add_runtime_dependency  'savon', '= 0.9.5'
-  s.add_runtime_dependency  'logging', '~> 1.6.1'
+  s.add_runtime_dependency  'logging', '~> 1.6', '>= 1.6.1'
 end


### PR DESCRIPTION
Resolves dependency conflicts in applications that require
later 1.x-series versions.
-  `~> 1.6`:    don't accidentally select 2.x
-  `>= 1.6.1`:  stay above the previous minimum

Original contribution by @nenadl via simplymeasured@5cd51885d5194444d9c1fb01b85a57c8c80a73bb
