### PR TITLE
Relax dependency on Nokogiri

### DIFF
--- a/winrm.gemspec
+++ b/winrm.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version	= '>= 1.9.0'
   s.add_runtime_dependency  'gssapi', '~> 1.0.0'
-  s.add_runtime_dependency  'nokogiri', '~> 1.5.0'
+  s.add_runtime_dependency  'nokogiri', '~> 1.5'
   s.add_runtime_dependency  'httpclient', '~> 2.2.0.2'
   s.add_runtime_dependency  'rubyntlm', '~> 0.1.1'
   s.add_runtime_dependency  'uuidtools', '~> 2.1.2'


### PR DESCRIPTION
Removes dependency conflicts in applications that require
later 1.x-series versions.
- `~> 1.5`:    don't accidentally select 2.x
