### PR TITLE
Update httpclient to 2.2.5

### DIFF
--- a/winrm.gemspec
+++ b/winrm.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version	= '>= 1.9.0'
   s.add_runtime_dependency  'gssapi', '~> 1.0.0'
   s.add_runtime_dependency  'nokogiri', '~> 1.5.0'
-  s.add_runtime_dependency  'httpclient', '~> 2.2.0.2'
+  s.add_runtime_dependency  'httpclient', '~> 2.2.5'
   s.add_runtime_dependency  'rubyntlm', '~> 0.1.1'
   s.add_runtime_dependency  'uuidtools', '~> 2.1.2'
   s.add_runtime_dependency  'savon', '= 0.9.5'


### PR DESCRIPTION
This is to resolve a dependency conflict between RiotGames/berkshelf and RiotGames/nexus_cli. Looking at the changes, I don't see any reason _not_ to update.
