### PR TITLE
Enable https and also an option to pass in ca_file

### DIFF
--- a/lib/winrm/client.rb
+++ b/lib/winrm/client.rb
@@ -49,8 +49,12 @@ module WinRM
     end
 
     def setup_transport(endpoint)
-      transport = opts[:ssl].eql?(true) ? 'https' : 'https'
-      transport = 'http'
+      if opts[:ssl].eql?(true)
+        transport = 'https'
+        @httpcli.ssl_config.set_trust_ca(opts[:ca_file]) unless opts[:ca_file].nil?
+      else
+        transport = 'http'
+      end
       @endpoint = URI("#{transport}://#{endpoint}:#{opts[:port]}/wsman")
       
       opts[:endpoint] = @endpoint


### PR DESCRIPTION
I need to use WinRM over SSL. This was not working. When I enabled it in the code I had problems to find where the CA ROOT certificate had to be placed. It only worked for me when I added it to httpclient/cacert.p7s. I added an option to pass a filename of a certstore in.
