### PR TITLE
Set http receive timeout to 2 minutes

### DIFF
--- a/lib/winrm/http/transport.rb
+++ b/lib/winrm/http/transport.rb
@@ -29,7 +29,10 @@ module WinRM
       def initialize(endpoint)
         @endpoint = endpoint.is_a?(String) ? URI.parse(endpoint) : endpoint
         @httpcli = HTTPClient.new(:agent_name => 'Ruby WinRM Client')
-        @httpcli.receive_timeout = 3600 # Set this to an unreasonable amount for now because WinRM has timeouts
+        @httpcli.receive_timeout = 120 # Set this to two minutes.  We set an
+                                       # OperationTimeout of 1 minute, so we
+                                       # shouldn't have to wait much longer
+                                       # than that.
         @logger = Logging.logger[self]
       end
 


### PR DESCRIPTION
I ran into a problem yesterday where I was talking to a box via winrm while the box was rebooting.  Because the box went away, the normal OperationTimeout didn't kick in and my script had to wait on the HttpClient timeout, which was set for 1 hour.

Since winrm uses an OperationTimeout of 60 seconds, I've changed the HttpClient receive_timeout to be 2 minutes.  This should be long enough to catch any valid response, but short enough to bomb out in a reasonable amount of time if the remote windows server disappears from the network mid-conversation.
