### PR TITLE
Fix PowerShell encoding from ASCII-8BIT to UTF-16LE for NON-ASCII string...

### DIFF
--- a/lib/winrm/winrm_service.rb
+++ b/lib/winrm/winrm_service.rb
@@ -252,14 +252,8 @@ module WinRM
     def run_powershell_script(script_file, &block)
       # if an IO object is passed read it..otherwise assume the contents of the file were passed
       script = script_file.kind_of?(IO) ? script_file.read : script_file
-
-      if(defined?(script.encode))
-        script = script.encode('UTF-16LE', 'UTF-8')
-        script = Base64.strict_encode64(script)
-      else
-        script = Base64.encode64(script).chomp
-      end
-
+      script = script.encode('UTF-16LE', 'UTF-8')
+      script = Base64.strict_encode64(script)
       shell_id = open_shell
       command_id = run_command(shell_id, "powershell -encodedCommand #{script}")
       command_output = get_command_output(shell_id, command_id, &block)


### PR DESCRIPTION
see https://github.com/WinRb/vagrant-windows/issues/182.

In `winrm.winrm_service.run_powershell_script`, script has encoded by `ASCII-8BIT`. When script contains NON-ASCII string, that code raises Unicode Error. So we can't do provisioning successfully.

This PR allows us to do provisioning by powershell like `netsh interface ip set address \"ローカル エリア接続\" static 192.168.56.101 255.255.255.0"`.

Please test this PR.
