### PR TITLE
Fixes #78: Expose http response status as an attribute of WinRMHTTPTransportError

### DIFF
--- a/lib/winrm/exceptions/exceptions.rb
+++ b/lib/winrm/exceptions/exceptions.rb
@@ -29,6 +29,14 @@ module WinRM
   class WinRMWSManFault < StandardError; end
 
   # Bad HTTP Transport
-  class WinRMHTTPTransportError < StandardError; end
+  class WinRMHTTPTransportError < StandardError
+    attr_reader :response_code
+
+    def initialize(msg, response_code)
+      @response_code = response_code
+      msg << " (#{response_code})."
+      super(msg)
+    end
+  end
 end # WinRM
 

--- a/lib/winrm/http/transport.rb
+++ b/lib/winrm/http/transport.rb
@@ -45,7 +45,7 @@ module WinRM
           end
           return doc
         else
-          raise WinRMHTTPTransportError, "Bad HTTP response returned from server (#{resp.status})."
+          raise WinRMHTTPTransportError, "Bad HTTP response returned from server", resp.status
         end
       end
 
@@ -134,7 +134,7 @@ Content-Type: application/octet-stream\r
       end
 
 
-      private 
+      private
 
 
       def init_krb

--- a/spec/exception_spec.rb
+++ b/spec/exception_spec.rb
@@ -1,0 +1,15 @@
+module WinRM
+  describe "Exceptions", :unit => true do
+    before(:all) do
+      @error = WinRMHTTPTransportError.new("Foo happened", 500)
+    end
+
+    it 'adds the response code to the message' do
+      expect(@error.message).to eql('Foo happened (500).')
+    end
+
+    it 'exposes the response code as an attribute' do
+      expect(@error.response_code).to be 500
+    end
+  end
+end


### PR DESCRIPTION
Fixes #78.
