### PR TITLE
initial working port ot test-kitchen upload implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,20 @@ iex $cmd
 WinRM::WinRMWebService.new(endpoint, :kerberos, :realm => 'MYREALM.COM')
 ```
 
+### Uploading files
+Files may be copied from the local machine to the winrm endpoint. Individual files or directories may be specified:
+```ruby
+WinRM::FileTransfer.upload(client, 'c:/dev/my_dir', '$env:AppData')
+```
+Or an array of several files and/or directories can be included:
+```ruby
+WinRM::FileTransfer.upload(client, ['c:/dev/file1.txt','c:/dev/dir1'], '$env:AppData')
+```
+**Note**:The winrm protocol poseses some limitations that can adversely affect the performance of large file transfers. By default, the above upload call will display a progress bar to indicate the progress of a file transfer currently underway. This progress bar can be suppressed by setting the `:quiet` option to `true`:
+```ruby
+WinRM::FileTransfer.upload(client, 'c:/dev/my_dir', '$env:AppData', :quiet => true)
+```
+
 ## Troubleshooting
 You may have some errors like ```WinRM::WinRMHTTPTransportError: Bad HTTP response returned from server (401).```.
 You can run the following commands on the server to try to solve the problem:

--- a/bin/rwinrm
+++ b/bin/rwinrm
@@ -22,12 +22,18 @@ require 'winrm'
 
 def parse_options
   options = {}
-  optparse = OptionParser.new do |opts|
-    opts.banner = "Usage: rwinrm endpoint [options]"
+  options[:auth_type] = :plaintext
+  options[:basic_auth_only] = true
+  options[:mode] = :repl
 
-    options[:auth_type] = :plaintext
-    options[:basic_auth_only] = true
-    options[:endpoint] = ARGV[0]
+  optparse = OptionParser.new do |opts|
+    opts.banner = "Usage: rwinrm [command] [local_path] [remote_path] endpoint [options]"
+    opts.separator  ""
+    opts.separator  "Commands"
+    opts.separator  "     repl(default)"
+    opts.separator  "     upload"
+    opts.separator  ""
+    opts.separator  "Options"
 
     opts.on('-u', '--user username', String, 'WinRM user name') do |v|
       options[:user] = v
@@ -38,27 +44,53 @@ def parse_options
     end
 
     opts.on('-h', '--help', 'Display this screen') do
-      puts opts
+      puts optparse
       exit
     end
   end
 
   optparse.parse!
+
+  if ARGV[0] && ARGV[0].downcase !~ /\A#{URI::regexp(['http', 'https'])}\z/
+    options[:mode] = ARGV.shift.downcase.to_sym
+
+    case options[:mode]
+    when :upload
+      options[:local_path] = ARGV.shift
+      options[:remote_path] = ARGV.shift
+
+      raise OptionParser::MissingArgument.new(:local_path) if options[:local_path].nil?
+      raise OptionParser::MissingArgument.new(:remote_path) if options[:remote_path].nil?
+    when :repl
+    else
+      raise OptionParser::InvalidArgument.new(options[:mode])
+    end
+  end
+  options[:endpoint] = ARGV.shift
+
   raise OptionParser::MissingArgument.new(:endpoint) if options[:endpoint].nil?
 
   options
-rescue OptionParser::InvalidOption, OptionParser::MissingArgument
+rescue OptionParser::InvalidOption, OptionParser::MissingArgument, OptionParser::InvalidArgument
   puts $!.message
   puts optparse
   exit 1
 end
 
-def repl(options)
-  client = WinRM::WinRMWebService.new(
-    options[:endpoint],
-    options[:auth_type].to_sym,
-    options)
+def winrm_client(options)
+  WinRM::WinRMWebService.new(
+      options[:endpoint],
+      options[:auth_type].to_sym,
+      options)
+end
 
+def upload(client, options)
+  bytes = WinRM::FileTransfer.upload(client, options[:local_path], options[:remote_path])
+  shell_id = client.open_shell()
+  puts "#{bytes} total bytes transfered"
+end
+
+def repl(client, options)
   shell_id = client.open_shell()
   command_id = client.run_command(shell_id, 'cmd')
 
@@ -79,6 +111,12 @@ def repl(options)
       client.write_stdin(shell_id, command_id, "#{buf}\r\n")
     end
   end
+end
+
+def run(options)
+  client = winrm_client(options)
+  method(options[:mode]).call(client, options)
+  exit 0
 rescue Interrupt
   # ctrl-c
 rescue StandardError => e
@@ -86,4 +124,4 @@ rescue StandardError => e
   exit 1
 end
 
-repl(parse_options())
+run(parse_options())

--- a/lib/winrm.rb
+++ b/lib/winrm.rb
@@ -35,3 +35,4 @@ end
 
 require 'winrm/helpers/iso8601_duration'
 require 'winrm/soap_provider'
+require 'winrm/file_transfer'

--- a/lib/winrm/exceptions/exceptions.rb
+++ b/lib/winrm/exceptions/exceptions.rb
@@ -20,6 +20,8 @@ module WinRM
   # Authorization Error
   class WinRMAuthorizationError < WinRMError; end
 
+  class WinRMUploadFailed < WinRMError; end
+
   # A Fault returned in the SOAP response. The XML node is a WSManFault
   class WinRMWSManFault < WinRMError
     attr_reader :fault_code

--- a/lib/winrm/file_transfer.rb
+++ b/lib/winrm/file_transfer.rb
@@ -1,0 +1,39 @@
+require 'winrm/file_transfer/remote_file'
+require 'winrm/file_transfer/remote_zip_file'
+
+module WinRM
+  # Perform file transfer operations between a local machine and winrm endpoint
+  class FileTransfer
+    # Upload one or more local files and directories to a remote directory
+    # @example copy a single directory to a winrm endpoint
+    #
+    #   WinRM::FileTransfer.upload(client, 'c:/dev/my_dir', '$env:AppData')
+    #
+    # @example copy several paths to the winrm endpoint
+    #
+    #   WinRM::FileTransfer.upload(client, ['c:/dev/file1.txt','c:/dev/dir1'], '$env:AppData')
+    #
+    # @param [WinRM::WinRMService] a winrm service client connected to the endpoint where the remote path resides
+    # @param [Array<String>] One or more paths that will be copied to the remote path. These can be files or directories to be deeply copied
+    # @param [String] The directory on the remote endpoint to copy the local items to. This path may contain powershell style environment variables
+    # @option opts [String] options to be used for the copy. Currently only :quiet is supported to suppress the progress bar
+    # @return [Fixnum] The total number of bytes copied
+    def self.upload(service, local_path, remote_path, opts = {})
+      file = nil
+      local_path = [local_path] if local_path.is_a? String
+
+      if local_path.count == 1 && !File.directory?(local_path[0])
+        file = RemoteFile.new(service, local_path[0], remote_path, opts)
+      else
+        file = RemoteZipFile.new(service, remote_path, opts)
+        local_path.each do |path|
+          file.add_file(path)
+        end
+      end
+
+      file.upload
+    ensure
+      file.close unless file.nil?
+    end
+  end
+end

--- a/lib/winrm/file_transfer/remote_file.rb
+++ b/lib/winrm/file_transfer/remote_file.rb
@@ -1,0 +1,184 @@
+require 'io/console'
+require 'json'
+require 'ruby-progressbar'
+
+module WinRM
+  class RemoteFile
+
+    attr_reader :local_path
+    attr_reader :remote_path
+    attr_reader :closed
+    attr_reader :options
+
+    def initialize(service, local_path, remote_path, opts = {})
+      @logger = Logging.logger[self]
+      @options = opts
+      @closed = false
+      @service = service
+      @shell = service.open_shell
+      @local_path = local_path
+      @remote_path = full_remote_path(local_path, remote_path)
+      @logger.debug("Creating RemoteFile of local '#{local_path}' at '#{@remote_path}'")
+    ensure
+      if !shell.nil?
+        ObjectSpace.define_finalizer( self, self.class.close(shell, service) )
+      end
+    end
+
+    def upload
+      raise WinRMUploadFailed.new("This RemoteFile is closed.") if closed
+      raise WinRMUploadFailed.new("Cannot find path: '#{local_path}'") unless File.exist?(local_path)
+
+      @remote_path, should_upload = powershell_batch do | builder |
+        builder << resolve_remote_command
+        builder << is_dirty_command
+      end
+
+      if should_upload
+        size = upload_to_remote
+        powershell_batch {|builder| builder << create_post_upload_command}
+      else
+        size = 0
+        logger.debug("Files are equal. Not copying #{local_path} to #{remote_path}")
+      end
+      size
+    end
+    
+    def close
+      service.close_shell(shell) unless shell.nil? or closed
+      @closed = true
+    end
+
+    protected
+
+    attr_reader :logger
+    attr_reader :service
+    attr_reader :shell
+
+    def self.close(shell_id, service)
+      proc { service.close_shell(shell_id) }
+    end
+
+    def full_remote_path(local_path, remote_path)
+      base_file_name = File.basename(local_path)
+      if File.basename(remote_path) != base_file_name
+        remote_path = File.join(remote_path, base_file_name)
+      end
+      remote_path
+    end
+
+    def resolve_remote_command
+      <<-EOH
+        $dest_file_path = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath("#{remote_path}")
+
+        if (!(Test-Path $dest_file_path)) {
+          $dest_dir = ([System.IO.Path]::GetDirectoryName($dest_file_path))
+          New-Item -ItemType directory -Force -Path $dest_dir | Out-Null
+        }
+
+        $dest_file_path
+      EOH
+    end
+
+    def is_dirty_command
+      local_md5 = Digest::MD5.file(local_path).hexdigest
+      <<-EOH
+        $dest_file_path = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath("#{remote_path}")
+
+        if (Test-Path $dest_file_path) {
+          $crypto_prov = new-object -TypeName System.Security.Cryptography.MD5CryptoServiceProvider
+          try {
+            $file = [System.IO.File]::Open($dest_file_path,
+              [System.IO.Filemode]::Open, [System.IO.FileAccess]::Read)
+            $guest_md5 = ([System.BitConverter]::ToString($crypto_prov.ComputeHash($file)))
+            $guest_md5 = $guest_md5.Replace("-","").ToLower()
+          }
+          finally {
+            $file.Dispose()
+          }
+          if ($guest_md5 -eq '#{local_md5}') {
+            return $false
+          }
+        }
+        if(Test-Path $dest_file_path){remove-item $dest_file_path -Force}
+        return $true
+      EOH
+    end
+
+    def upload_to_remote
+      logger.debug("Uploading '#{local_path}' to temp file '#{remote_path}'")
+      base64_host_file = Base64.encode64(IO.binread(local_path)).gsub("\n", "")
+      base64_array = base64_host_file.chars.to_a
+      unless options[:quiet]
+        console_width = IO.console.winsize[1]
+        bar = ProgressBar.create(:title => "Copying #{File.basename(local_path)}...", :total => base64_array.count, :length => console_width-1)
+      end      
+      base64_array.each_slice(8000 - remote_path.size) do |chunk|
+        cmd("echo #{chunk.join} >> \"#{remote_path}\"")
+        bar.progress += chunk.count unless options[:quiet]
+      end
+      base64_array.length
+    end
+
+    def decode_command
+      <<-EOH
+        $base64_string = Get-Content '#{remote_path}'
+        $bytes = [System.Convert]::FromBase64String($base64_string)
+        [System.IO.File]::WriteAllBytes('#{remote_path}', $bytes) | Out-Null
+      EOH
+    end
+
+    def create_post_upload_command
+      [decode_command]
+    end
+
+    def powershell_batch(&block)
+      ps_builder = []
+      yield ps_builder
+
+      commands = [ "$result = @{}" ]
+      idx = 0
+      ps_builder.flatten.each do |cmd_item|
+        commands << <<-EOH
+          $result.ret#{idx} = Invoke-Command { #{cmd_item} }
+        EOH
+        idx += 1
+      end
+      commands << "$(ConvertTo-Json $result)"
+
+      result = []
+      JSON.parse(powershell(commands.join("\n"))).each do |k,v|
+        result << v unless v.nil?
+      end
+      result unless result.empty?
+    end
+
+    def powershell(script)
+      script = "$ProgressPreference='SilentlyContinue';" + script
+      logger.debug("executing powershell script: \n#{script}")
+      script = script.encode('UTF-16LE', 'UTF-8')
+      script = Base64.strict_encode64(script)
+      cmd("powershell", ['-encodedCommand', script])
+    end
+
+    def cmd(command, arguments = [])
+      command_output = nil
+      out_stream = []
+      err_stream = []
+      service.run_command(shell, command, arguments) do |command_id|
+        command_output = service.get_command_output(shell, command_id) do |stdout, stderr|
+          out_stream << stdout if stdout
+          err_stream << stderr if stderr
+        end
+      end
+
+      if !command_output[:exitcode].zero? or !err_stream.empty?
+        raise WinRMUploadFailed,
+          :from => local_path,
+          :to => remote_path,
+          :message => command_output.inspect
+      end
+      out_stream.join.chomp
+    end
+  end
+end

--- a/lib/winrm/file_transfer/remote_zip_file.rb
+++ b/lib/winrm/file_transfer/remote_zip_file.rb
@@ -1,0 +1,60 @@
+require 'zip'
+
+module WinRM
+  class RemoteZipFile < RemoteFile
+
+    attr_reader :archive
+
+    def initialize(service, remote_path, opts = {})
+      @logger = Logging.logger[self]
+      @archive = create_archive(remote_path)
+      @unzip_remote_path = remote_path
+      remote_path = "$env:temp/WinRM_file_transfer"
+      super(service, @archive, remote_path, opts)
+    end
+
+    def add_file(path)
+      path = path.gsub("\\","/")
+      logger.debug("adding '#{path}' to zip file")
+      raise WinRMUploadFailed.new("Cannot find path: '#{path}'") unless File.exist?(path)
+      File.directory?(path) ? glob = File.join(path, "**/*") : glob = path
+      logger.debug("iterating files in '#{glob}'")
+      Zip::File.open(archive, 'w') do |zipfile|
+        Dir.glob(glob).each do |file|
+          logger.debug("adding zip entry for '#{file}'")
+          entry = Zip::Entry.new(archive, file.sub(File.dirname(path)+'/',''), nil, nil, nil, nil, nil, nil, ::Zip::DOSTime.new(2000))
+          zipfile.add(entry,file)
+        end
+      end
+    end
+
+    protected
+
+    def create_post_upload_command
+      super << extract_zip_command
+    end
+
+    private
+
+    def create_archive(remote_path)
+      archive_folder = File.join(ENV['TMP'] || ENV['TMPDIR'] || '/tmp', 'WinRM_file_transfer_local')
+      Dir.mkdir(archive_folder) unless File.exist?(archive_folder)
+      archive = File.join(archive_folder,File.basename(remote_path))+'.zip'
+      FileUtils.rm archive, :force=>true
+
+      archive
+    end
+
+    def extract_zip_command
+      <<-EOH
+        $destination = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath("#{@unzip_remote_path}")
+        $shellApplication = new-object -com shell.application 
+
+        $zipPackage = $shellApplication.NameSpace('#{remote_path}') 
+        mkdir $destination -ErrorAction SilentlyContinue | Out-Null
+        $destinationFolder = $shellApplication.NameSpace($destination) 
+        $destinationFolder.CopyHere($zipPackage.Items(),0x10) | Out-Null
+      EOH
+    end
+  end
+end

--- a/spec/file_transfer/remote_file_spec.rb
+++ b/spec/file_transfer/remote_file_spec.rb
@@ -1,0 +1,71 @@
+describe WinRM::RemoteFile, :integration => true do
+  
+  let(:this_file) { __FILE__ }
+  let(:service) { winrm_connection }
+  let(:destination) {"#{ENV['temp']}/WinRM_tests"}
+  after {
+    subject.close
+    FileUtils.rm_rf(destination)
+  }
+
+  context 'Upload a new file to directory path' do
+    subject {WinRM::RemoteFile.new(service, this_file, destination, :quiet => true)}
+
+    it 'copies the file inside the directory' do
+      expect(subject.upload).to be > 0
+      expect(File.exist?(File.join(destination, File.basename(this_file)))).to be_truthy
+    end
+    it 'copies the exact file content' do
+      expect(subject.upload).to be > 0
+      expect(File.read(File.join(destination, File.basename(this_file)))).to eq(File.read(this_file))
+    end
+
+  end
+
+  context 'Upload an identical file to directory path' do
+    subject {WinRM::RemoteFile.new(service, this_file, destination, :quiet => true)}
+    let (:next_transfer) {WinRM::RemoteFile.new(service, this_file, destination, :quiet => true)}
+
+    it 'does not copy the file' do
+      expect(subject.upload).to be > 0
+      expect(next_transfer.upload).to be == 0
+    end
+  end
+
+  context 'Upload a file to file path' do
+    subject {WinRM::RemoteFile.new(service, this_file, File.join(destination, File.basename(this_file)), :quiet => true)}
+
+    it 'copies the file to the exact path' do
+      expect(subject.upload).to be > 0
+      expect(File.exist?(File.join(destination, File.basename(this_file)))).to be_truthy
+    end
+  end
+
+  context 'Upload a new file to nested directory' do
+    let (:nested) {File.join(destination, 'nested')}
+    subject {WinRM::RemoteFile.new(service, this_file, nested, :quiet => true)}
+
+    it 'copies the file to the nested path' do
+      expect(subject.upload).to be > 0
+      expect(File.exist?(File.join(nested, File.basename(this_file)))).to be_truthy
+    end
+  end
+
+  context 'Upload a file after RemoteFile is closed' do
+    subject {WinRM::RemoteFile.new(service, this_file, destination, :quiet => true)}
+
+    it 'raises WinRMUploadFailed' do
+      expect(subject.upload).to be > 0
+      subject.close
+      expect{subject.upload}.to raise_error(WinRM::WinRMUploadFailed)
+    end
+  end
+
+  context 'Upload a bad path' do
+    subject {WinRM::RemoteFile.new(service, 'c:/some/bad/path', destination, :quiet => true)}
+
+    it 'raises WinRMUploadFailed' do
+      expect { subject.upload }.to raise_error(WinRM::WinRMUploadFailed)
+    end
+  end
+end

--- a/spec/file_transfer/remote_zip_file_spec.rb
+++ b/spec/file_transfer/remote_zip_file_spec.rb
@@ -1,0 +1,51 @@
+describe WinRM::RemoteZipFile, :integration => true do
+  
+  let(:this_dir) { File.dirname(__FILE__) }
+  let(:service) { winrm_connection }
+  let(:destination) {"#{ENV['temp']}/WinRM_tests"}
+  before { FileUtils.rm_rf(Dir.glob("#{ENV['temp'].gsub("\\","/")}/WinRM_*")) }
+  after { subject.close }
+  subject {WinRM::RemoteZipFile.new(service, destination, :quiet => true)}
+
+  context 'Upload a new directory' do
+    it 'copies the directory' do
+      subject.add_file(this_dir)
+      expect(subject.upload).to be > 0
+      expect(File.read(File.join(destination, "file_transfer", "remote_file_spec.rb"))).to eq(File.read(File.join(this_dir, 'remote_file_spec.rb')))
+      expect(File.read(File.join(destination, "file_transfer", "remote_zip_file_spec.rb"))).to eq(File.read(File.join(this_dir, 'remote_zip_file_spec.rb')))
+      expect(File.exist?(File.join(this_dir, "file_transfer.zip"))).to be_falsey
+      expect(File.exist?(File.join(destination, "file_transfer.zip"))).to be_falsey
+    end
+  end
+
+  context 'Upload an identical directory' do
+    let (:next_transfer) {WinRM::RemoteZipFile.new(service, destination, :quiet => true)}
+
+    it 'does not copy the directory' do
+      subject.add_file(this_dir)
+      expect(subject.upload).to be > 0
+      next_transfer.add_file(this_dir)
+      expect(next_transfer.upload).to be == 0
+    end
+  end
+
+  context 'Upload multiple entries' do
+    it 'copies each entry' do
+      subject.add_file(this_dir)
+      spec_helper = File.join(File.dirname(this_dir), 'spec_helper.rb')
+      subject.add_file(spec_helper)
+      expect(subject.upload).to be > 0
+      expect(File.read(File.join(destination, "file_transfer", "remote_file_spec.rb"))).to eq(File.read(File.join(this_dir, 'remote_file_spec.rb')))
+      expect(File.read(File.join(destination, "file_transfer", "remote_zip_file_spec.rb"))).to eq(File.read(File.join(this_dir, 'remote_zip_file_spec.rb')))
+      expect(File.read(File.join(destination, "spec_helper.rb"))).to eq(File.read(spec_helper))
+    end
+  end
+
+  context 'Upload a bad path' do
+    it 'raises WinRMUploadFailed' do
+      expect {
+        subject.add_file('c:/some/bad/path')
+        }.to raise_error(WinRM::WinRMUploadFailed)
+    end
+  end
+end

--- a/spec/file_transfer_spec.rb
+++ b/spec/file_transfer_spec.rb
@@ -1,0 +1,39 @@
+describe WinRM::FileTransfer, :unit => true do
+  
+  let(:this_file) { __FILE__ }
+  let(:remote_file) {double('RemoteFile')}
+  let(:remote_zip_file) {double('RemoteZipFile')}
+  
+  before {
+    allow(WinRM::RemoteFile).to receive(:new).and_return(remote_file)
+    allow(WinRM::RemoteZipFile).to receive(:new).and_return(remote_zip_file)
+  }
+  subject {WinRM::FileTransfer}
+
+  context 'copying a single file' do
+    it 'uploads a remote_file' do
+      expect(remote_file).to receive(:upload)
+      expect(remote_file).to receive(:close)
+      subject.upload("service", this_file, "c:/directory")
+    end
+  end
+
+  context 'copying a single directory' do
+    it 'uploads a remote_zip_file' do
+      expect(remote_zip_file).to receive(:add_file).with(File.dirname(this_file))
+      expect(remote_zip_file).to receive(:upload)
+      expect(remote_zip_file).to receive(:close)
+      subject.upload("service", File.dirname(this_file), "c:/directory")
+    end
+  end
+
+  context 'copying both a file and a directory' do
+    it 'adds both to a remote_zip_file' do
+      expect(remote_zip_file).to receive(:upload)
+      expect(remote_zip_file).to receive(:add_file).with(this_file)
+      expect(remote_zip_file).to receive(:add_file).with(File.dirname(this_file))
+      expect(remote_zip_file).to receive(:close)
+      subject.upload("service", [File.dirname(this_file), this_file], "c:/directory")
+    end
+  end
+end

--- a/winrm.gemspec
+++ b/winrm.gemspec
@@ -23,6 +23,8 @@ Gem::Specification.new do |s|
   s.rdoc_options	= %w(-x test/ -x examples/)
   s.extra_rdoc_files = %w(README.md LICENSE)
 
+  s.bindir = "bin"
+  s.executables   = ['rwinrm']
   s.required_ruby_version	= '>= 1.9.0'
   s.add_runtime_dependency  'gssapi', '~> 1.0'
   s.add_runtime_dependency  'httpclient', '~> 2.2', '>= 2.2.0.2'
@@ -32,6 +34,8 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency  'nori', '~> 2.0'
   s.add_runtime_dependency  'gyoku', '~> 1.0'
   s.add_runtime_dependency  'builder', '>= 2.1.2'
+  s.add_runtime_dependency  'rubyzip', '~> 1.1'
+  s.add_runtime_dependency  'ruby-progressbar', '~> 1.6'
   s.add_development_dependency 'rspec', '~> 3.0.0'
   s.add_development_dependency 'rake', '~> 10.3.2'
 end


### PR DESCRIPTION
This is an initial port but not ready for merging. Here is what needs to be added:
- Handle remote paths that are a file name. Currently if you do:

```
conn.upload_path('c:/dev/dsc_nugetserver/recipes/default.rb', 'c:/tmp/default.rb')
```

A directory called default.rb is created.
- Need to copy zip files to a temp directory so they dont linger in the destination directory.
- Add a progress bar for long uploads. Testing with a 4mb download takes about a minute.

I'll be implementing this shortly and will update here with progress.
