### PR TITLE
yield progress data to a code block in case users want to implement custom progress handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,20 @@ Or an array of several files and/or directories can be included:
 ```ruby
 WinRM::FileTransfer.upload(client, ['c:/dev/file1.txt','c:/dev/dir1'], '$env:AppData')
 ```
-**Note**:The winrm protocol poseses some limitations that can adversely affect the performance of large file transfers. By default, the above upload call will display a progress bar to indicate the progress of a file transfer currently underway. This progress bar can be suppressed by setting the `:quiet` option to `true`:
+
+#### Suppressing the progress bar
+The winrm protocol posesses some limitations that can adversely affect the performance of large file transfers. By default, the above upload call will display a progress bar to indicate the progress of a file transfer currently underway. This progress bar can be suppressed by setting the `:quiet` option to `true`:
 ```ruby
 WinRM::FileTransfer.upload(client, 'c:/dev/my_dir', '$env:AppData', :quiet => true)
+```
+
+#### Handling progress events
+If you want to implemnt your own custom progress handling, you can pass a code block and use the proggress data that `upload` yields to this block:
+```ruby
+WinRM::FileTransfer.upload(client, 'c:/dev/my_dir', '$env:AppData', :quiet => true) do |bytes_copied, total_bytes, local_path, remote_path|
+  bar = ProgressBar.create(:total => total_bytes.count) unless bar.nil?
+  bar.progress += bytes_copied
+end
 ```
 
 ## Troubleshooting

--- a/lib/winrm/file_transfer.rb
+++ b/lib/winrm/file_transfer.rb
@@ -17,8 +17,12 @@ module WinRM
     # @param [Array<String>] One or more paths that will be copied to the remote path. These can be files or directories to be deeply copied
     # @param [String] The directory on the remote endpoint to copy the local items to. This path may contain powershell style environment variables
     # @option opts [String] options to be used for the copy. Currently only :quiet is supported to suppress the progress bar
+    # @yield [Fixnum] Number of bytes copied in current payload sent to the winrm endpoint
+    # @yield [Fixnum] The total number of bytes to be copied
+    # @yield [String] Path of file being copied
+    # @yield [String] Target path on the winrm endpoint
     # @return [Fixnum] The total number of bytes copied
-    def self.upload(service, local_path, remote_path, opts = {})
+    def self.upload(service, local_path, remote_path, opts = {}, &block)
       file = nil
       local_path = [local_path] if local_path.is_a? String
 
@@ -31,7 +35,7 @@ module WinRM
         end
       end
 
-      file.upload
+      file.upload(&block)
     ensure
       file.close unless file.nil?
     end

--- a/lib/winrm/file_transfer/remote_file.rb
+++ b/lib/winrm/file_transfer/remote_file.rb
@@ -25,7 +25,7 @@ module WinRM
       end
     end
 
-    def upload
+    def upload(&block)
       raise WinRMUploadFailed.new("This RemoteFile is closed.") if closed
       raise WinRMUploadFailed.new("Cannot find path: '#{local_path}'") unless File.exist?(local_path)
 
@@ -35,7 +35,7 @@ module WinRM
       end
 
       if should_upload
-        size = upload_to_remote
+        size = upload_to_remote(&block)
         powershell_batch {|builder| builder << create_post_upload_command}
       else
         size = 0
@@ -105,17 +105,20 @@ module WinRM
       EOH
     end
 
-    def upload_to_remote
+    def upload_to_remote(&block)
       logger.debug("Uploading '#{local_path}' to temp file '#{remote_path}'")
       base64_host_file = Base64.encode64(IO.binread(local_path)).gsub("\n", "")
       base64_array = base64_host_file.chars.to_a
       unless options[:quiet]
         console_width = IO.console.winsize[1]
         bar = ProgressBar.create(:title => "Copying #{File.basename(local_path)}...", :total => base64_array.count, :length => console_width-1)
-      end      
+      end
+      bytes_copied = 0
       base64_array.each_slice(8000 - remote_path.size) do |chunk|
         cmd("echo #{chunk.join} >> \"#{remote_path}\"")
-        bar.progress += chunk.count unless options[:quiet]
+        bytes_copied += chunk.count
+        bar.progress += bytes_copied unless options[:quiet]
+        yield bytes_copied, base64_array.count, local_path, remote_path if block_given?
       end
       base64_array.length
     end

--- a/spec/file_transfer/remote_file_spec.rb
+++ b/spec/file_transfer/remote_file_spec.rb
@@ -15,6 +15,15 @@ describe WinRM::RemoteFile, :integration => true do
       expect(subject.upload).to be > 0
       expect(File.exist?(File.join(destination, File.basename(this_file)))).to be_truthy
     end
+    it 'yields progress data' do
+      total = subject.upload do |bytes_copied, total_bytes, local_path, remote_path|
+        expect(total_bytes).to be > 0
+        expect(bytes_copied).to eq(total_bytes)
+        expect(local_path).to eq(subject.local_path)
+        expect(remote_path).to eq(subject.remote_path)
+      end
+      expect(total).to be > 0
+    end
     it 'copies the exact file content' do
       expect(subject.upload).to be > 0
       expect(File.read(File.join(destination, File.basename(this_file)))).to eq(File.read(this_file))


### PR DESCRIPTION
This add the ability to perform custom handling with progress data yielded to a code block. Example usage:

``` ruby
WinRM::FileTransfer.upload(client, 'c:/dev/my_dir', '$env:AppData', :quiet => true) do |bytes_copied, total_bytes, local_path, remote_path|
  bar = ProgressBar.create(:total => total_bytes.count) unless bar.nil?
  bar.progress += bytes_copied
end
```

I still think the custom formatting of the executable would be neat but I want to get this out for now since it is the most useful and I plan to switch gears for a bit on some other work.
