### PR TITLE
Instantiate WinRMHTTPTransportError with new.

### DIFF
--- a/lib/winrm/http/transport.rb
+++ b/lib/winrm/http/transport.rb
@@ -45,7 +45,7 @@ module WinRM
           end
           return doc
         else
-          raise WinRMHTTPTransportError, "Bad HTTP response returned from server", resp.status
+          raise WinRMHTTPTransportError.new("Bad HTTP response returned from server", resp.status)
         end
       end
 


### PR DESCRIPTION
Kernel#raise does not take arguments for a custom Exception#initialize method. You need to instantiate the argument explicitly.
