### PR TITLE
handle MSFT_WmiErrors

### DIFF
--- a/lib/winrm/exceptions/exceptions.rb
+++ b/lib/winrm/exceptions/exceptions.rb
@@ -38,6 +38,18 @@ module WinRM
     end
   end
 
+  # A Fault returned in the SOAP response. The XML node is a MSFT_WmiError
+  class WinRMWMIError < WinRMError
+    attr_reader :error_code
+    attr_reader :error
+
+    def initialize(error, error_code)
+      @error = error
+      @error_code = error_code
+      super("[WMI ERROR CODE: #{error_code}]: #{error}")
+    end
+  end
+
   # non-200 response without a SOAP fault
   class WinRMHTTPTransportError < WinRMError
     attr_reader :status_code

--- a/spec/exception_spec.rb
+++ b/spec/exception_spec.rb
@@ -32,4 +32,21 @@ describe "Exceptions", :unit => true do
       expect(error).to be_kind_of(WinRM::WinRMError)
     end
   end
+
+  describe WinRM::WinRMWMIError do
+
+    let (:error) { WinRM::WinRMWMIError.new("message text", 77777) }
+
+    it 'exposes the error text as an attribute' do
+      expect(error.error).to eq('message text')
+    end
+
+    it 'exposes the error code as an attribute' do
+      expect(error.error_code).to eq 77777
+    end
+
+    it 'is a winrm error' do
+      expect(error).to be_kind_of(WinRM::WinRMError)
+    end
+  end
 end

--- a/spec/response_handler_spec.rb
+++ b/spec/response_handler_spec.rb
@@ -41,4 +41,18 @@ describe 'response handler', :unit => true do
       end
     end
   end
+
+  describe "failed 500 WMI error response" do
+    let(:wmi_error) { File.read("spec/stubs/responses/wmi_error_v2.xml") }
+
+    it 'raises a WinRMWMIError' do
+      handler = WinRM::ResponseHandler.new(wmi_error, 500)
+      begin
+        handler.parse_to_xml()
+      rescue WinRM::WinRMWMIError => e
+        expect(e.error_code).to eq('2150859173')
+        expect(e.error).to include('The WS-Management service cannot process the request.')
+      end
+    end
+  end
 end

--- a/spec/stubs/responses/wmi_error_v2.xml
+++ b/spec/stubs/responses/wmi_error_v2.xml
@@ -1,0 +1,41 @@
+<s:Envelope xmlns:a='http://schemas.xmlsoap.org/ws/2004/08/addressing' xmlns:e='http://schemas.xmlsoap.org/ws/2004/08/eventing' xml:lang='en-US' xmlns:n='http://schemas.xmlsoap.org/ws/2004/09/enumeration' xmlns:p='http://schemas.microsoft.com/wbem/wsman/1/wsman.xsd' xmlns:s='http://www.w3.org/2003/05/soap-envelope' xmlns:w='http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd' xmlns:x='http://schemas.xmlsoap.org/ws/2004/09/transfer'>
+  <s:Header>
+    <a:Action>http://schemas.dmtf.org/wbem/wsman/1/wsman/fault</a:Action>
+    <a:MessageID>uuid:B8829021-48C3-4F27-B94B-491DAC4F29B1</a:MessageID>
+    <a:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:To>
+  </s:Header>
+  <s:Body>
+    <s:Fault>
+      <s:Code>
+        <s:Value>s:Sender</s:Value>
+        <s:Subcode>
+          <s:Value>w:QuotaLimit</s:Value>
+        </s:Subcode>
+      </s:Code>
+      <s:Reason>
+        <s:Text xml:lang='en-US'>The WS-Management service cannot process the request. The maximum number of concurrent shells for this user has been exceeded. Close existing shells or raise the quota for this user. </s:Text>
+      </s:Reason>
+      <s:Detail>
+        <p:MSFT_WmiError b:IsCIM_Error='true' xmlns:b='http://schemas.dmtf.org/wbem/wsman/1/cimbinding.xsd' xmlns:cim='http://schemas.dmtf.org/wbem/wscim/1/common' xmlns:p='http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/MSFT_WmiError' xsi:type='p:MSFT_WmiError_Type' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
+          <p:CIMStatusCode xsi:type='cim:cimUnsignedInt'>27</p:CIMStatusCode>
+          <p:CIMStatusCodeDescription xsi:nil='true' xsi:type='cim:cimString'/>
+          <p:ErrorSource xsi:nil='true' xsi:type='cim:cimString'/>
+          <p:ErrorSourceFormat xsi:type='cim:cimUnsignedShort'>0</p:ErrorSourceFormat>
+          <p:ErrorType xsi:type='cim:cimUnsignedShort'>0</p:ErrorType>
+          <p:Message xsi:type='cim:cimString'>The WS-Management service cannot process the request. This user is allowed a maximum number of 30 concurrent shells, which has been exceeded. Close existing shells or raise the quota for this user. </p:Message>
+          <p:MessageID xsi:type='cim:cimString'>HRESULT 0x803381a5</p:MessageID>
+          <p:OtherErrorSourceFormat xsi:nil='true' xsi:type='cim:cimString'/>
+          <p:OtherErrorType xsi:nil='true' xsi:type='cim:cimString'/>
+          <p:OwningEntity xsi:nil='true' xsi:type='cim:cimString'/>
+          <p:PerceivedSeverity xsi:type='cim:cimUnsignedShort'>0</p:PerceivedSeverity>
+          <p:ProbableCause xsi:type='cim:cimUnsignedShort'>0</p:ProbableCause>
+          <p:ProbableCauseDescription xsi:nil='true' xsi:type='cim:cimString'/>
+          <p:error_Category xsi:type='cim:cimUnsignedInt'>30</p:error_Category>
+          <p:error_Code xsi:type='cim:cimUnsignedInt'>2150859173</p:error_Code>
+          <p:error_Type xsi:type='cim:cimString'>HRESULT</p:error_Type>
+          <p:error_WindowsErrorMessage xsi:type='cim:cimString'>The WS-Management service cannot process the request. This user is allowed a maximum number of 30 concurrent shells, which has been exceeded. Close existing shells or raise the quota for this user. </p:error_WindowsErrorMessage>
+        </p:MSFT_WmiError>
+      </s:Detail>
+    </s:Fault>
+  </s:Body>
+</s:Envelope>


### PR DESCRIPTION
Currently errors thrown as MSFT_WmiErrors are not properly messaged back to the user. Exceeding the shell limit would be an example of this type of error. This adds a new exception type to handle these.
