### PR TITLE
add user@host to repl prompt and extent the timeout from one minute to an hour

### DIFF
--- a/bin/rwinrm
+++ b/bin/rwinrm
@@ -56,6 +56,7 @@ def repl(options)
     options[:auth_type].to_sym,
     options)
 
+  client.set_timeout(3600)
   shell_id = client.open_shell()
   command_id = client.run_command(shell_id, 'cmd', "/K prompt [#{ARGV[0]}]$P$G")
 


### PR DESCRIPTION
this produces a prompt that looks like:

```
[vagrant@192.168.1.7]C:\Users\Administrator>
```

It also extends the repl timeout to an hour otherwise the repl throws an error after a minute of inactivity
