### PR TITLE
Switch to gssapi-1.2

### DIFF
--- a/lib/winrm/winrm_service.rb
+++ b/lib/winrm/winrm_service.rb
@@ -42,6 +42,7 @@ module WinRM
       case transport
       when :kerberos
         require 'gssapi'
+        require 'gssapi/extensions'
         @xfer = HTTP::HttpGSSAPI.new(endpoint, opts[:realm], opts[:service], opts[:keytab], opts)
       when :plaintext
         @xfer = HTTP::HttpPlaintext.new(endpoint, opts[:user], opts[:pass], opts)

--- a/winrm.gemspec
+++ b/winrm.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.bindir = "bin"
   s.executables   = ['rwinrm', 'rwinrmcp']
   s.required_ruby_version	= '>= 1.9.0'
-  s.add_runtime_dependency  'gssapi', '~> 1.0'
+  s.add_runtime_dependency  'gssapi', '~> 1.2'
   s.add_runtime_dependency  'httpclient', '~> 2.2', '>= 2.2.0.2'
   s.add_runtime_dependency  'rubyntlm', '~> 0.4.0'
   s.add_runtime_dependency  'uuidtools', '~> 2.1.2'


### PR DESCRIPTION
Switch to recent version of gssapi gem.
This fixed issue https://github.com/WinRb/WinRM/issues/54 for me, thus no trouble connecting to AD with kerberos anymore.
