### PR TITLE
Fix issue 59

### DIFF
--- a/lib/winrm/winrm_service.rb
+++ b/lib/winrm/winrm_service.rb
@@ -249,6 +249,13 @@ module WinRM
         output[:exitcode] = REXML::XPath.first(resp_doc, "//#{NS_WIN_SHELL}:ExitCode").text.to_i
       end
       output
+    rescue WinRMWSManFault => e
+      # If no output is available before the wsman:OperationTimeout expires,
+      # the server MUST return a WSManFault with the Code attribute equal to
+      # 2150858793. When the client receives this fault, it SHOULD issue 
+      # another Receive request.
+      # http://msdn.microsoft.com/en-us/library/cc251676.aspx
+      retry if e.fault_code == '2150858793'
     end
 
     # Clean-up after a command.

--- a/spec/issue_59_spec.rb
+++ b/spec/issue_59_spec.rb
@@ -1,0 +1,15 @@
+# encoding: UTF-8
+describe 'issue 59', integration: true do
+  before(:all) do
+    @winrm = winrm_connection
+  end
+
+  describe 'long running script without output' do
+    it 'should not error' do
+      output = @winrm.powershell('sleep 60; Write-Host "Hello"')
+      expect(output).to have_exit_code 0
+      expect(output).to have_stdout_match(/Hello/)
+      expect(output).to have_no_stderr
+    end
+  end
+end


### PR DESCRIPTION
If no output is available before the wsman:OperationTimeout expires, the server MUST return a WSManFault with the Code attribute equal to 2150858793. When the client receives this fault, it SHOULD issue another Receive request.