### PR TITLE
UTF-8 as default codepage

### DIFF
--- a/lib/winrm/winrm_service.rb
+++ b/lib/winrm/winrm_service.rb
@@ -226,6 +226,8 @@ module WinRM
       output = Output.new
       REXML::XPath.match(resp_doc, "//#{NS_WIN_SHELL}:Stream").each do |n|
         next if n.text.nil? || n.text.empty?
+        # force encoding fixes the error:
+        # Encoding::CompatibilityError: incompatible encoding regexp match (UTF-8 regexp with ASCII-8BIT string)
         stream = { n.attributes['Name'].to_sym => Base64.decode64(n.text).force_encoding('utf-8') }
         output[:data] << stream
         yield stream[:stdout], stream[:stderr] if block_given?

--- a/lib/winrm/winrm_service.rb
+++ b/lib/winrm/winrm_service.rb
@@ -96,7 +96,7 @@ module WinRM
     def open_shell(shell_opts = {}, &block)
       i_stream = shell_opts.has_key?(:i_stream) ? shell_opts[:i_stream] : 'stdin'
       o_stream = shell_opts.has_key?(:o_stream) ? shell_opts[:o_stream] : 'stdout stderr'
-      codepage = shell_opts.has_key?(:codepage) ? shell_opts[:codepage] : 437
+      codepage = shell_opts.has_key?(:codepage) ? shell_opts[:codepage] : 65001 # utf8 as default codepage (from https://msdn.microsoft.com/en-us/library/dd317756(VS.85).aspx)
       noprofile = shell_opts.has_key?(:noprofile) ? shell_opts[:noprofile] : 'FALSE'
       h_opts = { "#{NS_WSMAN_DMTF}:OptionSet" => { "#{NS_WSMAN_DMTF}:Option" => [noprofile, codepage],
         :attributes! => {"#{NS_WSMAN_DMTF}:Option" => {'Name' => ['WINRS_NOPROFILE','WINRS_CODEPAGE']}}}}
@@ -226,7 +226,7 @@ module WinRM
       output = Output.new
       REXML::XPath.match(resp_doc, "//#{NS_WIN_SHELL}:Stream").each do |n|
         next if n.text.nil? || n.text.empty?
-        stream = { n.attributes['Name'].to_sym => Base64.decode64(n.text) }
+        stream = { n.attributes['Name'].to_sym => Base64.decode64(n.text).force_encoding('utf-8') }
         output[:data] << stream
         yield stream[:stdout], stream[:stderr] if block_given?
       end

--- a/spec/powershell_spec.rb
+++ b/spec/powershell_spec.rb
@@ -92,11 +92,11 @@ describe 'winrm client powershell', integration: true do
         "xmlns=\"http://schemas.microsoft.com/powershell/2004/04\">" \
         "<S S=\"Error\">, world!_x000D__x000A_</S></Objs>")
     end
+  end
 
-    describe 'it should handle utf-8 characters' do
-      subject(:output) { @winrm.powershell('echo "✓1234-äöü"') }
-      it { should have_exit_code 0 }
-      it { should have_stdout_match(/✓1234-äöü/) }
-    end
+  describe 'it should handle utf-8 characters' do
+    subject(:output) { @winrm.powershell('echo "✓1234-äöü"') }
+    it { should have_exit_code 0 }
+    it { should have_stdout_match(/✓1234-äöü/) }
   end
 end

--- a/spec/powershell_spec.rb
+++ b/spec/powershell_spec.rb
@@ -92,5 +92,11 @@ describe 'winrm client powershell', integration: true do
         "xmlns=\"http://schemas.microsoft.com/powershell/2004/04\">" \
         "<S S=\"Error\">, world!_x000D__x000A_</S></Objs>")
     end
+
+    describe 'it should handle utf-8 characters' do
+      subject(:output) { @winrm.powershell('echo "✓1234-äöü"') }
+      it { should have_exit_code 0 }
+      it { should have_stdout_match(/✓1234-äöü/) }
+    end
   end
 end


### PR DESCRIPTION
I recently had trouble when echoing strings to stdout/stderr on windows systems (over WinRM) that contained non-ascii chars, especially umlauts (occur in latin1) and other utf8 characters: They were always messed up in the winrm response.

I found that the gem defaultly specifies codepage 437 when opening the shell (https://github.com/WinRb/WinRM/blob/ec9140063bc47f92b52f3a84bde1e4b0800ed911/lib/winrm/winrm_service.rb#L99) so that only characters from this codepage (which contains only the ascii set and some other chars) are displayed correctly. 

When passing the option ```:codepage => 65001``` (which corresponds to utf-8 according to this index: https://msdn.microsoft.com/en-us/library/dd317756(VS.85).aspx) to ```open_shell```, windows successfully receives the utf8 chars. 

But when getting the command output, I get the error ```Encoding::CompatibilityError: incompatible encoding regexp match (UTF-8 regexp with ASCII-8BIT string)```. If I add ```force_encoding('utf-8')``` when getting the command output, the error is gone and the utf-8 chars are received correctly on the client (on both windows and linux clients).

In order to support the whole unicode character set in this Gem, this PR changes the default codepage for WinRM shell to utf-8.

Maybe this change is too radical by introducing a new default and will break dependent gems or programs... 
But I couldn't find another solution - adding ```force_encoding('utf-8')``` would break the response when using another codepage as utf-8 for the shell. Nevertheless, I think utf-8 as default seems appropriate nowadays. The spec suite is passing on both windows and linux.

A less intruding alternative (completely backward-compatible): Introduce a ```utf-8 => true``` option that automatically sets the codepage to 650001 and forces the encoding to utf-8 on the output (but leaves the default & other codepages alone) - but I think that would be less elegant.

Spec is included and tested on windows 8.1 & ubuntu linux (ruby 1.9.3) against a windows 2012r2 server.