### PR TITLE
Fix 'match undefined' error in be_a_uid matcher

### DIFF
--- a/spec/matchers.rb
+++ b/spec/matchers.rb
@@ -66,7 +66,7 @@ end
 RSpec::Matchers.define :be_a_uid do
   match do |actual|
     # WinRM1.1 returns uuid's prefixed with 'uuid:' where as later versions do not
-    !actual.nil? && actual.match(/^(uuid:)*\w{8}-\w{4}-\w{4}-\w{4}-\w{12}$/)
+    actual && actual.to_s.match(/^(uuid:)*\w{8}-\w{4}-\w{4}-\w{4}-\w{12}$/)
   end
   failure_message do |actual|
     "expected a uid, but got '#{actual}'"


### PR DESCRIPTION
Integration tests were failing with `undefined method match' for #<MatchData "CDD2E408-F04D-49AE-89B9-4E22D22C594B" 1:nil>` error.