### PR TITLE
Fix path to specs so tests actually run

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,14 +9,14 @@ require 'bundler/gem_tasks'
 Dir.chdir(File.expand_path('../', __FILE__))
 
 RSpec::Core::RakeTask.new(:spec) do |task|
-  task.pattern = 'test/spec/*_spec.rb'
+  task.pattern = 'spec/*_spec.rb'
   task.rspec_opts = ['--color', '-f documentation']
   task.rspec_opts << '-tunit'
 end
 
 # Run the integration test suite
 RSpec::Core::RakeTask.new(:integration) do |task|
-  task.pattern = 'test/spec/*_spec.rb'
+  task.pattern = 'spec/*_spec.rb'
   task.rspec_opts = ['--color', '-f documentation']
   task.rspec_opts << '-tintegration'
 end


### PR DESCRIPTION
Unsure why this only started to happen after upgrading rspec from 3.0 to 3.2, but it did. It appears like the tests should have never run properly.