### PR TITLE
rwinrm : modified regexp to allow dashes in hostnames

### DIFF
--- a/bin/rwinrm
+++ b/bin/rwinrm
@@ -32,7 +32,7 @@ def parse_options
   options = {}
   fail 'Missing required options' unless ARGV.length == 1
 
-  m = /^(?<user>[a-z0-9\.\!\$ _-]+)@{1}(?<host>[a-z0-9\.]+)(?<port>:[0-9]+)?/i.match(ARGV[0])
+  m = /^(?<user>[a-z0-9\.\!\$ _-]+)@{1}(?<host>[a-z0-9\.\$ -]+)(?<port>:[0-9]+)?/i.match(ARGV[0])
   fail "#{ARGV[0]} is an invalid host" unless m
   options[:user] = m[:user]
   options[:endpoint] = "http://#{m[:host]}#{m[:port] || ':5985'}/wsman"

--- a/bin/rwinrm
+++ b/bin/rwinrm
@@ -32,7 +32,7 @@ def parse_options
   options = {}
   fail 'Missing required options' unless ARGV.length == 1
 
-  m = /^(?<user>[a-z0-9\.\!\$ _-]+)@{1}(?<host>[a-z0-9\.\$ -]+)(?<port>:[0-9]+)?/i.match(ARGV[0])
+  m = /^(?<user>[a-z0-9\.\!\$ _-]+)@{1}(?<host>[a-z0-9\.\-]+)(?<port>:[0-9]+)?/i.match(ARGV[0])
   fail "#{ARGV[0]} is an invalid host" unless m
   options[:user] = m[:user]
   options[:endpoint] = "http://#{m[:host]}#{m[:port] || ':5985'}/wsman"


### PR DESCRIPTION
Following issue #138, I've modified the regexp in rwinrm to allow dashes in hostnames