### PR TITLE
'vagrant up' was failing

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,4 +6,5 @@ VAGRANTFILE_API_VERSION = '2'
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = 'mwrock/Windows2012R2'
+  config.vm.communicator = :winrm
 end


### PR DESCRIPTION
By default `config.vm.communicator` is `:ssh` and should be changed to `:winrm` for Windows guests.

With this change `vagrant up` works and all `bundle exec rake integration` tests pass.