### PR TITLE
Relax version pins on dev dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,9 @@
 # encoding: UTF-8
 source 'https://rubygems.org'
 gemspec
+
+group :development do
+  # Use a tighter specification until rubocop issues are fixed.
+  # Then remove this
+  gem 'rubocop', '~> 0.28.0'
+end

--- a/lib/winrm/http/transport.rb
+++ b/lib/winrm/http/transport.rb
@@ -218,7 +218,7 @@ Content-Type: application/octet-stream\r
 
         iov1 = GSSAPI::LibGSSAPI::GssIOVBufferDesc.new(
           FFI::Pointer.new(iov.address + (GSSAPI::LibGSSAPI::GssIOVBufferDesc.size * 1)))
-        iov1[:type] =  (GSSAPI::LibGSSAPI::GSS_IOV_BUFFER_TYPE_DATA)
+        iov1[:type] = (GSSAPI::LibGSSAPI::GSS_IOV_BUFFER_TYPE_DATA)
         iov1[:buffer].value = str
 
         iov2 = GSSAPI::LibGSSAPI::GssIOVBufferDesc.new(
@@ -258,11 +258,11 @@ Content-Type: application/octet-stream\r
 
         iov1 = GSSAPI::LibGSSAPI::GssIOVBufferDesc.new(
           FFI::Pointer.new(iov.address + (GSSAPI::LibGSSAPI::GssIOVBufferDesc.size * 1)))
-        iov1[:type] =  (GSSAPI::LibGSSAPI::GSS_IOV_BUFFER_TYPE_DATA)
+        iov1[:type] = (GSSAPI::LibGSSAPI::GSS_IOV_BUFFER_TYPE_DATA)
 
         iov2 = GSSAPI::LibGSSAPI::GssIOVBufferDesc.new(
           FFI::Pointer.new(iov.address + (GSSAPI::LibGSSAPI::GssIOVBufferDesc.size * 2)))
-        iov2[:type] =  (GSSAPI::LibGSSAPI::GSS_IOV_BUFFER_TYPE_DATA)
+        iov2[:type] = (GSSAPI::LibGSSAPI::GSS_IOV_BUFFER_TYPE_DATA)
 
         str.force_encoding('BINARY')
         str.sub!(/^.*Content-Type: application\/octet-stream\r\n(.*)--Encrypted.*$/m, '\1')

--- a/lib/winrm/output.rb
+++ b/lib/winrm/output.rb
@@ -23,19 +23,19 @@ module WinRM
     end
 
     def output
-      self[:data].flat_map do | line |
+      self[:data].flat_map do |line|
         [line[:stdout], line[:stderr]]
       end.compact.join
     end
 
     def stdout
-      self[:data].map do | line |
+      self[:data].map do |line|
         line[:stdout]
       end.compact.join
     end
 
     def stderr
-      self[:data].map do | line |
+      self[:data].map do |line|
         line[:stderr]
       end.compact.join
     end

--- a/spec/cmd_spec.rb
+++ b/spec/cmd_spec.rb
@@ -45,7 +45,8 @@ describe 'winrm client cmd', integration: true do
 
       script = 'echo Hello & echo , world! 1>&2'
 
-      @captured_stdout, @captured_stderr = '', ''
+      @captured_stdout = ''
+      @captured_stderr = ''
       @winrm.cmd(script) do |stdout, stderr|
         @captured_stdout << stdout if stdout
         @captured_stderr << stderr if stderr
@@ -91,7 +92,7 @@ describe 'winrm client cmd', integration: true do
   describe 'ipconfig with a block' do
     subject(:stdout) do
       outvar = ''
-      @winrm.cmd('ipconfig') do |stdout, _stderr |
+      @winrm.cmd('ipconfig') do |stdout, _stderr|
         outvar << stdout
       end
       outvar

--- a/spec/powershell_spec.rb
+++ b/spec/powershell_spec.rb
@@ -62,7 +62,8 @@ describe 'winrm client powershell', integration: true do
       $host.ui.WriteErrorLine(', world!')
       eos
 
-      @captured_stdout, @captured_stderr = '', ''
+      @captured_stdout = ''
+      @captured_stderr = ''
       @winrm.powershell(script) do |stdout, stderr|
         @captured_stdout << stdout if stdout
         @captured_stderr << stderr if stderr

--- a/winrm.gemspec
+++ b/winrm.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'nori', '~> 2.0'
   s.add_runtime_dependency 'gyoku', '~> 1.0'
   s.add_runtime_dependency 'builder', '>= 2.1.2'
-  s.add_development_dependency 'rspec', '~> 3.2.0'
-  s.add_development_dependency 'rake', '~> 10.3.2'
-  s.add_development_dependency 'rubocop', '~> 0.28.0'
+  s.add_development_dependency 'rspec', '~> 3.2'
+  s.add_development_dependency 'rake', '~> 10.3'
+  s.add_development_dependency 'rubocop', '~> 0.28'
 end

--- a/winrm.gemspec
+++ b/winrm.gemspec
@@ -7,26 +7,26 @@ Gem::Specification.new do |s|
   s.platform = Gem::Platform::RUBY
   s.name = 'winrm'
   s.version = version
-  s.date		= Date.today.to_s
+  s.date = Date.today.to_s
 
   s.author = ['Dan Wanek', 'Paul Morton']
   s.email = ['dan.wanek@gmail.com', 'paul@themortonsonline.com']
   s.homepage = 'https://github.com/WinRb/WinRM'
 
   s.summary = 'Ruby library for Windows Remote Management'
-  s.description	= <<-EOF
+  s.description = <<-EOF
     Ruby library for Windows Remote Management
   EOF
   s.license = 'Apache-2.0'
 
   s.files = `git ls-files`.split(/\n/)
   s.require_path = 'lib'
-  s.rdoc_options	= %w(-x test/ -x examples/)
+  s.rdoc_options = %w(-x test/ -x examples/)
   s.extra_rdoc_files = %w(README.md LICENSE)
 
   s.bindir = 'bin'
-  s.executables   = ['rwinrm']
-  s.required_ruby_version	= '>= 1.9.0'
+  s.executables = ['rwinrm']
+  s.required_ruby_version = '>= 1.9.0'
   s.add_runtime_dependency 'gssapi', '~> 1.2'
   s.add_runtime_dependency 'httpclient', '~> 2.2', '>= 2.2.0.2'
   s.add_runtime_dependency 'rubyntlm', '~> 0.4.0'


### PR DESCRIPTION
When bundling winrm with other software (like ChefDK), the highly specific version pins on these dependencies force us to include multiple different versions of rake, rspec and rubocop (because bundler still resolves dev dependencies for consistency, even if we don't install it).  Would you consider relaxing this?