### PR TITLE
Widen logging gem constraint to include 2.0

### DIFF
--- a/winrm.gemspec
+++ b/winrm.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'httpclient', '~> 2.2', '>= 2.2.0.2'
   s.add_runtime_dependency 'rubyntlm', '~> 0.4.0'
   s.add_runtime_dependency 'uuidtools', '~> 2.1.2'
-  s.add_runtime_dependency 'logging', '~> 1.6', '>= 1.6.1'
+  s.add_runtime_dependency 'logging', ['>= 1.6.1', '< 3.0']
   s.add_runtime_dependency 'nori', '~> 2.0'
   s.add_runtime_dependency 'gyoku', '~> 1.0'
   s.add_runtime_dependency 'builder', '>= 2.1.2'


### PR DESCRIPTION
@mwrock This would address issue #147. I ran DEBUG logging locally and didn't have any issues with v2.0 of the logging gem :smile:.

Instead of constraining it to '< 3.0' I thought about constraining it to '< 2.1' but more than likely that will create work in the future without any benefit.