### PR TITLE
WIP - Fix exit code when there is no stdout

### DIFF
--- a/spec/cmd_spec.rb
+++ b/spec/cmd_spec.rb
@@ -11,6 +11,13 @@ describe 'winrm client cmd', integration: true do
     it { should have_no_stderr }
   end
 
+  describe 'exit without stdout' do
+    subject(:output) { @winrm.cmd('exit 100') }
+    it { should have_exit_code 100 }
+    it { should have_no_stdout }
+    it { should have_no_stderr }
+  end
+
   describe 'ipconfig' do
     subject(:output) { @winrm.cmd('ipconfig') }
     it { should have_exit_code 0 }


### PR DESCRIPTION
This fixes #154 and is currently just a failing test illustrating the problem.