### PR TITLE
adding command_executor to support multiple commands from a single shell

### DIFF
--- a/lib/winrm/command_executor.rb
+++ b/lib/winrm/command_executor.rb
@@ -1,0 +1,242 @@
+# -*- encoding: utf-8 -*-
+#
+# Copyright 2015 Shawn Neal <sneal@sneal.net>
+# Copyright 2015 Matt Wrock <matt@mattwrock.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module WinRM
+  # Object which can execute multiple commands and Powershell scripts in
+  # one shared remote shell session. The maximum number of commands per
+  # shell is determined by interrogating the remote host when the session
+  # is opened and the remote shell is automatically recycled before the
+  # threshold is reached.
+  #
+  # @author Shawn Neal <sneal@sneal.net>
+  # @author Matt Wrock <matt@mattwrock.com>
+  # @author Fletcher Nichol <fnichol@nichol.ca>
+  class CommandExecutor
+    # Closes an open remote shell session left open
+    # after a command executor is garbage collecyted.
+    #
+    # @param shell_id [String] the remote shell identifier
+    # @param service [WinRM::WinRMWebService] a winrm web service object
+    def self.finalize(shell_id, service)
+      proc { service.close_shell(shell_id) }
+    end
+
+    # @return [Integer,nil] the safe maximum number of commands that can
+    #   be executed in one remote shell session, or `nil` if the
+    #   threshold has not yet been determined
+    attr_reader :max_commands
+
+    # @return [WinRM::WinRMWebService] a WinRM web service object
+    attr_reader :service
+
+    # @return [String,nil] the identifier for the current open remote
+    #   shell session, or `nil` if the session is not open
+    attr_reader :shell
+
+    # Creates a CommandExecutor given a `WinRM::WinRMWebService` object.
+    #
+    # @param service [WinRM::WinRMWebService] a winrm web service object
+    #   responds to `#debug` and `#info` (default: `nil`)
+    def initialize(service)
+      @service = service
+      @logger = service.logger
+      @command_count = 0
+    end
+
+    # Closes the open remote shell session. This method can be called
+    # multiple times, even if there is no open session.
+    def close
+      return if shell.nil?
+
+      service.close_shell(shell)
+      remove_finalizer
+      @shell = nil
+    end
+
+    # Opens a remote shell session for reuse. The maxiumum
+    # command-per-shell threshold is also determined the first time this
+    # method is invoked and cached for later invocations.
+    #
+    # @return [String] the remote shell session indentifier
+    def open
+      close
+      retryable(service.retry_limit, service.retry_delay) { @shell = service.open_shell }
+      add_finalizer(shell)
+      @command_count = 0
+      determine_max_commands unless max_commands
+      shell
+    end
+
+    # Runs a CMD command.
+    #
+    # @param command [String] the command to run on the remote system
+    # @param arguments [Array<String>] arguments to the command
+    # @yield [stdout, stderr] yields more live access the standard
+    #   output and standard error streams as they are returns, if
+    #   streaming behavior is desired
+    # @return [WinRM::Output] output object with stdout, stderr, and
+    #   exit code
+    def run_cmd(command, arguments = [], &block)
+      reset if command_count_exceeded?
+      ensure_open_shell!
+
+      @command_count += 1
+      result = nil
+      service.run_command(shell, command, arguments) do |command_id|
+        result = service.get_command_output(shell, command_id, &block)
+      end
+      result
+    end
+
+    # Run a Powershell script that resides on the local box.
+    #
+    # @param script_file [IO,String] an IO reference for reading the
+    #   Powershell script or the actual file contents
+    # @yield [stdout, stderr] yields more live access the standard
+    #   output and standard error streams as they are returns, if
+    #   streaming behavior is desired
+    # @return [WinRM::Output] output object with stdout, stderr, and
+    #   exit code
+    def run_powershell_script(script_file, &block)
+      # this code looks overly compact in an attempt to limit local
+      # variable assignments that may contain large strings and
+      # consequently bloat the Ruby VM
+      run_cmd(
+        'powershell',
+        [
+          '-encodedCommand',
+          ::WinRM::PowershellScript.new(
+            safe_script(script_file.is_a?(IO) ? script_file.read : script_file)
+          ).encoded
+        ],
+        &block
+      )
+    end
+
+    private
+
+    # @return [Integer] the default maximum number of commands which can be
+    #   executed in one remote shell session on "older" versions of Windows
+    # @api private
+    LEGACY_LIMIT = 15
+
+    # @return [Integer] the default maximum number of commands which can be
+    #   executed in one remote shell session on "modern" versions of Windows
+    # @api private
+    MODERN_LIMIT = 1500
+
+    # @return [String] the PowerShell command used to determine the version
+    #   of Windows
+    # @api private
+    PS1_OS_VERSION = '[environment]::OSVersion.Version.tostring()'.freeze
+
+    # @return [Integer] the number of executed commands on the remote
+    #   shell session
+    # @api private
+    attr_accessor :command_count
+
+    # @return [#debug,#info] the logger
+    # @api private
+    attr_reader :logger
+
+    # Creates a finalizer for this connection which will close the open
+    # remote shell session when the object is garabage collected or on
+    # Ruby VM shutdown.
+    #
+    # @param shell_id [String] the remote shell identifier
+    # @api private
+    def add_finalizer(shell_id)
+      ObjectSpace.define_finalizer(self, self.class.finalize(shell_id, service))
+    end
+
+    # @return [true,false] whether or not the number of exeecuted commands
+    #   have exceeded the maxiumum threshold
+    # @api private
+    def command_count_exceeded?
+      command_count > max_commands.to_i
+    end
+
+    # Ensures that there is an open remote shell session.
+    #
+    # @raise [WinRM::WinRMError] if there is no open shell
+    # @api private
+    def ensure_open_shell!
+      fail ::WinRM::WinRMError, "#{self.class}#open must be called " \
+        'before any run methods are invoked' if shell.nil?
+    end
+
+    # Determines the safe maximum number of commands that can be executed
+    # on a remote shell session by interrogating the remote host.
+    #
+    # @api private
+    def determine_max_commands
+      os_version = run_powershell_script(PS1_OS_VERSION).stdout.chomp
+      @max_commands = os_version < '6.2' ? LEGACY_LIMIT : MODERN_LIMIT
+      @max_commands -= 2 # to be safe
+    end
+
+    # Removes any finalizers for this connection.
+    #
+    # @api private
+    def remove_finalizer
+      ObjectSpace.undefine_finalizer(self)
+    end
+
+    # Closes the remote shell session and opens a new one.
+    #
+    # @api private
+    def reset
+      logger.debug("Resetting WinRM shell (Max command limit is #{max_commands})")
+      open
+    end
+
+    # Yields to a block and reties the block if certain rescuable
+    # exceptions are raised.
+    #
+    # @param retries [Integer] the number of times to retry before failing
+    # @option delay [Float] the number of seconds to wait until
+    #   attempting a retry
+    # @api private
+    def retryable(retries, delay)
+      yield
+    rescue *RESCUE_EXCEPTIONS_ON_ESTABLISH.call => e
+      if (retries -= 1) > 0
+        logger.info("[WinRM] connection failed. retrying in #{delay} seconds (#{e.inspect})")
+        sleep(delay)
+        retry
+      else
+        logger.warn("[WinRM] connection failed, terminating (#{e.inspect})")
+        raise
+      end
+    end
+
+    RESCUE_EXCEPTIONS_ON_ESTABLISH = lambda do
+      [
+        Errno::EACCES, Errno::EADDRINUSE, Errno::ECONNREFUSED,
+        Errno::ECONNRESET, Errno::ENETUNREACH, Errno::EHOSTUNREACH,
+        ::WinRM::WinRMHTTPTransportError, ::WinRM::WinRMAuthorizationError,
+        HTTPClient::KeepAliveDisconnected,
+        HTTPClient::ConnectTimeoutError
+      ].freeze
+    end
+
+    # suppress the progress stream from leaking to stderr
+    def safe_script(script)
+      "$ProgressPreference='SilentlyContinue';" + script
+    end
+  end
+end

--- a/spec/command_executor_spec.rb
+++ b/spec/command_executor_spec.rb
@@ -1,0 +1,440 @@
+# -*- encoding: utf-8 -*-
+#
+# Author:: Fletcher (<fnichol@nichol.ca>)
+#
+# Copyright (C) 2015, Fletcher Nichol
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'winrm/command_executor'
+
+require 'base64'
+require 'securerandom'
+
+describe WinRM::CommandExecutor, unit: true do
+  let(:logged_output)   { StringIO.new }
+  let(:shell_id)        { 'shell-123' }
+  let(:executor_args)   { [service, logger] }
+  let(:executor) { WinRM::CommandExecutor.new(service) }
+  let(:service) do
+    double(
+      'winrm_service',
+      logger: Logging.logger['test'],
+      retry_limit: 1,
+      retry_delay: 1
+    )
+  end
+
+  let(:version_output) do
+    o = ::WinRM::Output.new
+    o[:exitcode] = 0
+    o[:data].concat([{ stdout: '6.3.9600.0\r\n' }])
+    o
+  end
+
+  before do
+    allow(service).to receive(:open_shell).and_return(shell_id)
+
+    stub_powershell_script(
+      shell_id,
+      "$ProgressPreference='SilentlyContinue';[environment]::OSVersion.Version.tostring()",
+      version_output
+    )
+  end
+
+  describe '#close' do
+    it 'calls service#close_shell' do
+      executor.open
+      expect(service).to receive(:close_shell).with(shell_id)
+
+      executor.close
+    end
+
+    it 'only calls service#close_shell once for multiple calls' do
+      executor.open
+      expect(service).to receive(:close_shell).with(shell_id).once
+
+      executor.close
+      executor.close
+      executor.close
+    end
+
+    it 'undefines finalizer' do
+      allow(service).to receive(:close_shell)
+      allow(ObjectSpace).to receive(:define_finalizer) { |e, _| e == executor }
+      expect(ObjectSpace).to receive(:undefine_finalizer).with(executor)
+      executor.open
+
+      executor.close
+    end
+  end
+
+  describe '#open' do
+    it 'calls service#open_shell' do
+      expect(service).to receive(:open_shell).and_return(shell_id)
+
+      executor.open
+    end
+
+    it 'defines a finalizer' do
+      expect(ObjectSpace).to receive(:define_finalizer) do |e, _|
+        expect(e).to eq(executor)
+      end
+
+      executor.open
+    end
+
+    it 'returns a shell id as a string' do
+      expect(executor.open).to eq shell_id
+    end
+
+    describe 'failed connection attempts' do
+      let(:error) { HTTPClient::ConnectTimeoutError }
+      let(:limit) { 3 }
+      let(:delay) { 0.1 }
+
+      before do
+        allow(service).to receive(:open_shell).and_raise(error)
+        allow(service).to receive(:retry_delay).and_return(delay)
+        allow(service).to receive(:retry_limit).and_return(limit)
+      end
+
+      it 'attempts to connect :retry_limit times' do
+        begin
+          allow(service).to receive(:open_shell).exactly.times(limit)
+          executor.open
+        rescue # rubocop:disable Lint/HandleExceptions
+          # the raise is not what is being tested here, rather its side-effect
+        end
+      end
+
+      it 'raises the inner error after retries' do
+        expect { executor.open }.to raise_error(error)
+      end
+    end
+
+    describe 'for modern windows distributions' do
+      let(:version_output) do
+        o = ::WinRM::Output.new
+        o[:exitcode] = 0
+        o[:data].concat([{ stdout: '6.3.9600.0\r\n' }])
+        o
+      end
+
+      it 'sets #max_commands to 1500 - 2' do
+        expect(executor.max_commands).to eq nil
+        executor.open
+
+        expect(executor.max_commands).to eq(1500 - 2)
+      end
+    end
+
+    describe 'for older/legacy windows distributions' do
+      let(:version_output) do
+        o = ::WinRM::Output.new
+        o[:exitcode] = 0
+        o[:data].concat([{ stdout: '6.1.8500.0\r\n' }])
+        o
+      end
+
+      it 'sets #max_commands to 15 - 2' do
+        expect(executor.max_commands).to eq nil
+        executor.open
+
+        expect(executor.max_commands).to eq(15 - 2)
+      end
+    end
+  end
+
+  describe '#run_cmd' do
+    describe 'when #open has not been previously called' do
+      it 'raises a WinRMError error' do
+        expect { executor.run_cmd('nope') }.to raise_error(
+          ::WinRM::WinRMError,
+          "#{executor.class}#open must be called before any run methods are invoked"
+        )
+      end
+    end
+
+    describe 'when #open has been previously called' do
+      let(:command_id) { 'command-123' }
+
+      let(:echo_output) do
+        o = ::WinRM::Output.new
+        o[:exitcode] = 0
+        o[:data].concat([
+          { stdout: 'Hello\r\n' },
+          { stderr: 'Psst\r\n' }
+        ])
+        o
+      end
+
+      before do
+        stub_cmd(shell_id, 'echo', ['Hello'], echo_output, command_id)
+
+        executor.open
+      end
+
+      it 'calls service#run_command' do
+        expect(service).to receive(:run_command).with(shell_id, 'echo', ['Hello'])
+
+        executor.run_cmd('echo', ['Hello'])
+      end
+
+      it 'calls service#get_command_output to get results' do
+        expect(service).to receive(:get_command_output).with(shell_id, command_id)
+
+        executor.run_cmd('echo', ['Hello'])
+      end
+
+      it 'calls service#get_command_output with a block to get results' do
+        blk = proc { |_, _| 'something' }
+        expect(service).to receive(:get_command_output).with(shell_id, command_id, &blk)
+
+        executor.run_cmd('echo', ['Hello'], &blk)
+      end
+
+      it 'returns an Output object hash' do
+        expect(executor.run_cmd('echo', ['Hello'])).to eq echo_output
+      end
+
+      it 'runs the block  in #get_command_output when given' do
+        io_out = StringIO.new
+        io_err = StringIO.new
+        stub_cmd(
+          shell_id,
+          'echo',
+          ['Hello'],
+          echo_output,
+          command_id
+        ).and_yield(echo_output.stdout, echo_output.stderr)
+        output = executor.run_cmd('echo', ['Hello']) do |stdout, stderr|
+          io_out << stdout if stdout
+          io_err << stderr if stderr
+        end
+
+        expect(io_out.string).to eq 'Hello\r\n'
+        expect(io_err.string).to eq 'Psst\r\n'
+        expect(output).to eq echo_output
+      end
+    end
+
+    describe 'when called many times over time' do
+      # use a 'old' version of windows with lower max_commands threshold
+      # to trigger quicker shell recyles
+      let(:version_output) do
+        o = ::WinRM::Output.new
+        o[:exitcode] = 0
+        o[:data].concat([{ stdout: '6.1.8500.0\r\n' }])
+        o
+      end
+
+      let(:echo_output) do
+        o = ::WinRM::Output.new
+        o[:exitcode] = 0
+        o[:data].concat([{ stdout: 'Hello\r\n' }])
+        o
+      end
+
+      before do
+        allow(service).to receive(:open_shell).and_return('s1', 's2')
+        allow(service).to receive(:close_shell)
+        allow(service).to receive(:run_command).and_yield('command-xxx')
+        allow(service).to receive(:get_command_output).and_return(echo_output)
+        stub_powershell_script(
+          's1',
+          "$ProgressPreference='SilentlyContinue';[environment]::OSVersion.Version.tostring()",
+          version_output
+        )
+      end
+
+      it 'resets the shell when #max_commands threshold is tripped' do
+        iterations = 35
+        reset_times = iterations / (15 - 2)
+
+        expect(service).to receive(:close_shell).exactly(reset_times).times
+        executor.open
+        iterations.times { executor.run_cmd('echo', ['Hello']) }
+      end
+    end
+  end
+
+  describe '#run_powershell_script' do
+    describe 'when #open has not been previously called' do
+      it 'raises a WinRMError error' do
+        expect { executor.run_powershell_script('nope') }.to raise_error(
+          ::WinRM::WinRMError,
+          "#{executor.class}#open must be called before any run methods are invoked"
+        )
+      end
+    end
+
+    describe 'when #open has been previously called' do
+      let(:command_id) { 'command-123' }
+
+      let(:echo_output) do
+        o = ::WinRM::Output.new
+        o[:exitcode] = 0
+        o[:data].concat([
+          { stdout: 'Hello\r\n' },
+          { stderr: 'Psst\r\n' }
+        ])
+        o
+      end
+
+      before do
+        stub_powershell_script(
+          shell_id,
+          "$ProgressPreference='SilentlyContinue';echo Hello",
+          echo_output,
+          command_id
+        )
+
+        executor.open
+      end
+
+      it 'calls service#run_command' do
+        expect(service).to receive(:run_command).with(
+          shell_id,
+          'powershell',
+          [
+            '-encodedCommand',
+            ::WinRM::PowershellScript.new("$ProgressPreference='SilentlyContinue';echo Hello")
+              .encoded
+          ]
+        )
+
+        executor.run_powershell_script('echo Hello')
+      end
+
+      it 'calls service#get_command_output to get results' do
+        expect(service).to receive(:get_command_output).with(shell_id, command_id)
+
+        executor.run_powershell_script('echo Hello')
+      end
+
+      it 'calls service#get_command_output with a block to get results' do
+        blk = proc { |_, _| 'something' }
+        expect(service).to receive(:get_command_output).with(shell_id, command_id, &blk)
+
+        executor.run_powershell_script('echo Hello', &blk)
+      end
+
+      it 'returns an Output object hash' do
+        expect(executor.run_powershell_script('echo Hello')).to eq echo_output
+      end
+
+      it 'runs the block  in #get_command_output when given' do
+        io_out = StringIO.new
+        io_err = StringIO.new
+        stub_cmd(shell_id, 'echo', ['Hello'], echo_output, command_id)
+          .and_yield(echo_output.stdout, echo_output.stderr)
+        output = executor.run_powershell_script('echo Hello') do |stdout, stderr|
+          io_out << stdout if stdout
+          io_err << stderr if stderr
+        end
+
+        expect(io_out.string).to eq 'Hello\r\n'
+        expect(io_err.string).to eq 'Psst\r\n'
+        expect(output).to eq echo_output
+      end
+    end
+
+    describe 'when called many times over time' do
+      # use a 'old' version of windows with lower max_commands threshold
+      # to trigger quicker shell recyles
+      let(:version_output) do
+        o = ::WinRM::Output.new
+        o[:exitcode] = 0
+        o[:data].concat([{ stdout: '6.1.8500.0\r\n' }])
+        o
+      end
+
+      let(:echo_output) do
+        o = ::WinRM::Output.new
+        o[:exitcode] = 0
+        o[:data].concat([{ stdout: 'Hello\r\n' }])
+        o
+      end
+
+      before do
+        allow(service).to receive(:open_shell).and_return('s1', 's2')
+        allow(service).to receive(:close_shell)
+        allow(service).to receive(:run_command).and_yield('command-xxx')
+        allow(service).to receive(:get_command_output).and_return(echo_output)
+        stub_powershell_script(
+          's1',
+          "$ProgressPreference='SilentlyContinue';[environment]::OSVersion.Version.tostring()",
+          version_output
+        )
+      end
+
+      it 'resets the shell when #max_commands threshold is tripped' do
+        iterations = 35
+        reset_times = iterations / (15 - 2)
+
+        expect(service).to receive(:close_shell).exactly(reset_times).times
+        executor.open
+        iterations.times { executor.run_powershell_script('echo Hello') }
+      end
+    end
+  end
+
+  describe '#shell' do
+    it 'is initially nil' do
+      expect(executor.shell).to eq nil
+    end
+
+    it 'is set after #open is called' do
+      executor.open
+
+      expect(executor.shell).to eq shell_id
+    end
+  end
+
+  def decode(powershell)
+    Base64.strict_decode64(powershell).encode('UTF-8', 'UTF-16LE')
+  end
+
+  def debug_line_with(msg)
+    /^D, .* : #{Regexp.escape(msg)}/
+  end
+
+  def regexify(string)
+    Regexp.new(Regexp.escape(string))
+  end
+
+  def regexify_line(string)
+    Regexp.new("^#{Regexp.escape(string)}$")
+  end
+
+  # rubocop:disable Metrics/ParameterLists
+  def stub_cmd(shell_id, cmd, args, output, command_id = nil, &block)
+    command_id ||= SecureRandom.uuid
+
+    allow(service).to receive(:run_command).with(shell_id, cmd, args).and_yield(command_id)
+    allow(service).to receive(:get_command_output).with(shell_id, command_id, &block)
+      .and_return(output)
+  end
+
+  def stub_powershell_script(shell_id, script, output, command_id = nil)
+    stub_cmd(
+      shell_id,
+      'powershell',
+      ['-encodedCommand', ::WinRM::PowershellScript.new(script).encoded],
+      output,
+      command_id
+    )
+  end
+  # rubocop:enable Metrics/ParameterLists
+end

--- a/spec/powershell_spec.rb
+++ b/spec/powershell_spec.rb
@@ -4,12 +4,6 @@ describe 'winrm client powershell', integration: true do
     @winrm = winrm_connection
   end
 
-  describe 'empty string' do
-    subject(:output) { @winrm.powershell('') }
-    it { should have_exit_code 4_294_770_688 }
-    it { should have_stderr_match(/Cannot process the command because of a missing parameter/) }
-  end
-
   describe 'ipconfig' do
     subject(:output) { @winrm.powershell('ipconfig') }
     it { should have_exit_code 0 }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,10 +7,14 @@ require_relative 'matchers'
 
 # Creates a WinRM connection for integration tests
 module ConnectionHelper
+  # rubocop:disable AbcSize
   def winrm_connection
-    WinRM::WinRMWebService.new(
+    winrm = WinRM::WinRMWebService.new(
       config[:endpoint], config[:auth_type].to_sym, config[:options])
+    winrm.logger.level = :error
+    winrm
   end
+  # rubocop:enable AbcSize
 
   def config
     @config ||= begin


### PR DESCRIPTION
Deprecates `WinRM::WinRMWebService` methods `cmd`, `run_cmd`, `powershell`, and `run_powershell_script` in favor of the `run_cmd` and `run_powershell_script` methods of the `WinRM::CommandExecutor` class. The `CommandExecutor` allows multiple commands to be run from the same WinRM shell providing a significant performance improvement whwn issuing multiple calls.

This PR is a prerequisite for https://github.com/WinRb/winrm-fs/pull/28 which depend on `CommandExecutor`, which is being added here since it provides value beyond just transferring files.