### PR TITLE
fixes #173 and fixes #181 using codepage 437 for os versions older than 6.1

### DIFF
--- a/lib/winrm/helpers/powershell_script.rb
+++ b/lib/winrm/helpers/powershell_script.rb
@@ -30,8 +30,13 @@ module WinRM
     # --EncodedCommand argument.
     # @return [String] The UTF-16LE base64 encoded script
     def encoded
-      encoded_script = text.encode('UTF-16LE', 'UTF-8')
+      encoded_script = safe_script(text).encode('UTF-16LE', 'UTF-8')
       Base64.strict_encode64(encoded_script)
+    end
+
+    # suppress the progress stream from leaking to stderr
+    def safe_script(script)
+      "$ProgressPreference='SilentlyContinue';" + script
     end
   end
 end


### PR DESCRIPTION
Uses a winrm `Identify` call which is akin to the powershell `test-wsman` command to gather os info instead of making an initial powershell call upon opening a shell. This has a couple advantages:
1. Gets os info independent of a shell since we have to settle on a codepage before openning a shell
2. Faster than the powershell call (1 round trip not 3 and no need to create powershell runspace)
3. oh yeah...get to declare one more namespace and xml namespaces are the best!