### PR TITLE
create channel binding from ssl cert and pass to ntlm type3 message

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,6 +35,7 @@ install:
   - ps: winrm create winrm/config/Listener?Address=*+Transport=HTTPS "@{Hostname=`"localhost`";CertificateThumbprint=`"$($env:winrm_cert)`"}"
   - ps: winrm set winrm/config/client/auth '@{Basic="true"}'
   - ps: winrm set winrm/config/service/auth '@{Basic="true"}'
+  - ps: winrm set winrm/config/service/auth '@{CbtHardeningLevel="Strict"}'
   - ps: winrm set winrm/config/service '@{AllowUnencrypted="true"}'
   - ps: $env:PATH="C:\Ruby$env:ruby_version\bin;$env:PATH"
   - ps: Write-Host $env:PATH

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,16 +12,6 @@ environment:
     - ruby_version: "21"
       winrm_endpoint: http://localhost:5985/wsman
 
-    - ruby_version: "21"
-      winrm_auth_type: ssl
-      winrm_endpoint: https://localhost:5986/wsman
-      winrm_no_ssl_peer_verification: true
-
-    - ruby_version: "21"
-      winrm_auth_type: ssl
-      winrm_endpoint: https://localhost:5986/wsman
-      use_ssl_peer_fingerprint: true
-
 clone_folder: c:\projects\winrm
 clone_depth: 1
 branches:

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # WinRM Gem Changelog
 
+# 1.7.0
+- Bump rubyntlm gem to 0.6.0 to get channel binding support for HTTPS fixing connections to endoints with `CbtHardeningLevel` set to `Strict`
+
 # 1.6.1
 - Use codepage 437 by default on os versions older than Windows 7 and Windows Server 2008 R2
 

--- a/lib/winrm/version.rb
+++ b/lib/winrm/version.rb
@@ -3,5 +3,5 @@
 # WinRM module
 module WinRM
   # The version of the WinRM library
-  VERSION = '1.6.1'
+  VERSION = '1.7.0'
 end

--- a/lib/winrm/winrm_service.rb
+++ b/lib/winrm/winrm_service.rb
@@ -54,7 +54,6 @@ module WinRM
     end
 
     def init_negotiate_transport(opts)
-      require 'rubyntlm'
       HTTP::HttpNegotiate.new(opts[:endpoint], opts[:user], opts[:pass], opts)
     end
 
@@ -69,7 +68,11 @@ module WinRM
     end
 
     def init_ssl_transport(opts)
-      HTTP::HttpSSL.new(opts[:endpoint], opts[:user], opts[:pass], opts[:ca_trust_path], opts)
+      if opts[:basic_auth_only]
+        HTTP::BasicAuthSSL.new(opts[:endpoint], opts[:user], opts[:pass], opts)
+      else
+        HTTP::HttpNegotiate.new(opts[:endpoint], opts[:user], opts[:pass], opts)
+      end
     end
 
     # Operation timeout.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,7 +33,6 @@ module ConnectionHelper
       config[:options][:ssl_peer_fingerprint] = ENV['winrm_cert']
     end
     config[:endpoint] = ENV['winrm_endpoint'] if ENV['winrm_endpoint']
-    config[:auth_type] = ENV['winrm_auth_type'] if ENV['winrm_auth_type']
   end
 
   def merge_config_option_from_environment(config, key)

--- a/spec/transport_spec.rb
+++ b/spec/transport_spec.rb
@@ -42,3 +42,83 @@ describe WinRM::HTTP::HttpNegotiate, unit: true do
     end
   end
 end
+
+describe 'WinRM connection', integration: true do
+  let(:winrm_connection) do
+    endpoint = config[:endpoint].dup
+    if auth_type == :ssl
+      endpoint.sub!('5985', '5986')
+      endpoint.sub!('http', 'https')
+    end
+    winrm = WinRM::WinRMWebService.new(
+      endpoint, auth_type, options)
+    winrm.logger.level = :error
+    winrm
+  end
+  let(:options) do
+    opts = {}
+    opts[:user] = config[:options][:user]
+    opts[:pass] = config[:options][:pass]
+    opts[:basic_auth_only] = basic_auth_only
+    opts[:no_ssl_peer_verification] = no_ssl_peer_verification
+    opts[:ssl_peer_fingerprint] = ssl_peer_fingerprint
+    opts
+  end
+  let(:basic_auth_only) { false }
+  let(:no_ssl_peer_verification) { false }
+  let(:ssl_peer_fingerprint) { nil }
+
+  subject(:output) do
+    executor = winrm_connection.create_executor
+    executor.run_cmd('ipconfig')
+  end
+
+  shared_examples 'a valid_connection' do
+    it 'has a 0 exit code' do
+      expect(subject).to have_exit_code 0
+    end
+
+    it 'includes command output' do
+      expect(subject).to have_stdout_match(/Windows IP Configuration/)
+    end
+
+    it 'has no errors' do
+      expect(subject).to have_no_stderr
+    end
+  end
+
+  context 'HttpPlaintext' do
+    let(:basic_auth_only) { true }
+    let(:auth_type) { :plaintext }
+
+    it_behaves_like 'a valid_connection'
+  end
+
+  context 'HttpNegotiate' do
+    let(:auth_type) { :negotiate }
+
+    it_behaves_like 'a valid_connection'
+  end
+
+  context 'BasicAuthSSL', skip: ENV['winrm_cert'].nil? do
+    let(:basic_auth_only) { true }
+    let(:auth_type) { :ssl }
+    let(:no_ssl_peer_verification) { true }
+
+    it_behaves_like 'a valid_connection'
+  end
+
+  context 'Negotiate over SSL', skip: ENV['winrm_cert'].nil? do
+    let(:auth_type) { :ssl }
+    let(:no_ssl_peer_verification) { true }
+
+    it_behaves_like 'a valid_connection'
+  end
+
+  context 'SSL fingerprint', skip: ENV['winrm_cert'].nil? do
+    let(:auth_type) { :ssl }
+    let(:ssl_peer_fingerprint) { ENV['winrm_cert'] }
+
+    it_behaves_like 'a valid_connection'
+  end
+end

--- a/winrm.gemspec
+++ b/winrm.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9.0'
   s.add_runtime_dependency 'gssapi', '~> 1.2'
   s.add_runtime_dependency 'httpclient', '~> 2.2', '>= 2.2.0.2'
-  s.add_runtime_dependency 'rubyntlm', '~> 0.5.0', '>= 0.5.3'
+  s.add_runtime_dependency 'rubyntlm', '~> 0.6.0'
   s.add_runtime_dependency 'logging', ['>= 1.6.1', '< 3.0']
   s.add_runtime_dependency 'nori', '~> 2.0'
   s.add_runtime_dependency 'gyoku', '~> 1.0'


### PR DESCRIPTION
This creates a `Net::NTLM::ChannelBinding` from the ssl cert and passes that to the NTLM type 3 message.

While its not clear from reviewing the WinRM transport code, if one looks at https://github.com/nahi/httpclient/blob/master/lib/httpclient/auth.rb, they will note that the httpclient gem uses the rubyntlm gem (if loaded) as its authenticator. The key difference between the usage of rubyntlm from httpclient and this gem is that httpclient only uses it to handle authentication and does not attempt to encode/decode the message body. Because WinRM loads rubyntlm, negotiate auth via rubyntlm is always used using the `HttpSSL` transport.

Out of curiosity, I tried using `basic_auth_only` with the `HttpSSL` transport. that always yielded a `WinRMAuthorizationError` so I doubt that works for anyone today and this pr removes it as a possibility.

Ideally, passing the channel binding would happen in the httpclient gem and I intend to create a PR to do that. However, it will take time for users to upgrade their httpclient so this PR ensures that WinRM will always use channel binding.