### PR TITLE
bringing in the command_output_decoder to restore BOM stripping

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # WinRM Gem Changelog
 
+# 1.7.2
+- Fix regression where BOM appears in 2008R2 output and is not stripped
+
 # 1.7.1
 - Fix OS version comparisons for Windows 10 using `Gem::Version` instead of strings
 

--- a/lib/winrm/command_output_decoder.rb
+++ b/lib/winrm/command_output_decoder.rb
@@ -1,0 +1,53 @@
+# -*- encoding: utf-8 -*-
+#
+# Copyright 2016 Shawn Neal <sneal@sneal.net>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'base64'
+
+module WinRM
+  # Handles decoding a raw output response
+  class CommandOutputDecoder
+    # Decode the raw SOAP output into decoded and human consumable text,
+    # Decodes and replaces invalid unicode characters.
+    # @param raw_output [String] The raw encoded output
+    # @return [String] The decoded output
+    def decode(raw_output)
+      decoded_text = decode_raw_output(raw_output)
+      decoded_text = handle_invalid_encoding(decoded_text)
+      decoded_text = remove_bom(decoded_text)
+      decoded_text
+    end
+
+    private
+
+    def decode_raw_output(raw_output)
+      Base64.decode64(raw_output).force_encoding('utf-8')
+    end
+
+    def handle_invalid_encoding(decoded_text)
+      return decoded_text if decoded_text.valid_encoding?
+      if decoded_text.respond_to?(:scrub)
+        decoded_text.scrub
+      else
+        decoded_text.encode('utf-16', invalid: :replace, undef: :replace).encode('utf-8')
+      end
+    end
+
+    def remove_bom(decoded_text)
+      # remove BOM which 2008R2 applies
+      decoded_text.sub("\xEF\xBB\xBF", '')
+    end
+  end
+end

--- a/lib/winrm/version.rb
+++ b/lib/winrm/version.rb
@@ -3,5 +3,5 @@
 # WinRM module
 module WinRM
   # The version of the WinRM library
-  VERSION = '1.7.1'
+  VERSION = '1.7.2'
 end

--- a/spec/command_output_decoder_spec.rb
+++ b/spec/command_output_decoder_spec.rb
@@ -1,0 +1,37 @@
+# encoding: UTF-8
+
+require 'winrm/command_output_decoder'
+
+describe WinRM::CommandOutputDecoder, unit: true do
+  let(:raw_output_with_bom) do
+    '77u/' \
+    'ICAgQ29ubmVjdGlvbi1zcGVjaWZpYyBETlMgU3VmZml4ICAuIDogDQogICBMaW5rLWxvY2FsIElQdjYgQWRkcmVzcyA' \
+    'uIC4gLiAuIC4gOiBmZTgwOjo5MTFkOjE2OTQ6NTcwNDo1YjI5JTEyDQogICBJUHY0IEFkZHJlc3MuIC4gLiAuIC4gLi' \
+    'AuIC4gLiAuIC4gOiAxMC4wLjIuMTUNCiAgIFN1Ym5ldCBNYXNrIC4gLiAuIC4gLiAuIC4gLiAuIC4gLiA6IDI1NS4yN' \
+    'TUuMjU1LjANCiAgIERlZmF1bHQgR2F0ZXdheSAuIC4gLiAuIC4gLiAuIC4gLiA6IDEwLjAuMi4yDQoNClR1bm5lbCBh' \
+    'ZGFwdGVyIGlzYXRhcC57RjBENTY2RDgtNzlCMS00QUYwLUJENUQtMkM5RkVEOEI3MTE3fToNCg0KICAgTWVkaWEgU3R' \
+    'hdGUgLiAuIC4gLiAuIC4gLiAuIC4gLiAuIDogTWVkaWEgZGlzY29ubmVjdGVkDQogICBDb25uZWN0aW9uLXNwZWNpZm' \
+    'ljIEROUyBTdWZmaXggIC4gOiANCg0KVHVubmVsIGFkYXB0ZXIgVGVyZWRvIFR1bm5lbGluZyBQc2V1ZG8tSW50ZXJmY' \
+    'WNlOg0KDQogICBDb25uZWN0aW9uLXNwZWNpZmljIEROUyBTdWZmaXggIC4gOiANCiAgIElQdjYgQWRkcmVzcy4gLiAu' \
+    'IC4gLiAuIC4gLiAuIC4gLiA6IDIwMDE6MDo5ZDM4OjZhYmQ6NGJiOjI4YjU6ZjVmZjpmZGYwDQogICBMaW5rLWxvY2F' \
+    'sIElQdjYgQWRkcmVzcyAuIC4gLiAuIC4gOiBmZTgwOjo0YmI6MjhiNTpmNWZmOmZkZjAlMTQNCiAgIERlZmF1bHQgR2' \
+    'F0ZXdheSAuIC4gLiAuIC4gLiAuIC4gLiA6IDo6DQo='
+  end
+  let(:expected) do
+    "   Connection-specific DNS Suffix  . : \r\n   Link-local IPv6 Address . . . . . : fe80::911" \
+    "d:1694:5704:5b29%12\r\n   IPv4 Address. . . . . . . . . . . : 10.0.2.15\r\n   Subnet Mask ." \
+    " . . . . . . . . . . : 255.255.255.0\r\n   Default Gateway . . . . . . . . . : 10.0.2.2\r\n" \
+    "\r\nTunnel adapter isatap.{F0D566D8-79B1-4AF0-BD5D-2C9FED8B7117}:\r\n\r\n   Media State . ." \
+    " . . . . . . . . . : Media disconnected\r\n   Connection-specific DNS Suffix  . : \r\n\r\nT" \
+    "unnel adapter Teredo Tunneling Pseudo-Interface:\r\n\r\n   Connection-specific DNS Suffix  " \
+    ". : \r\n   IPv6 Address. . . . . . . . . . . : 2001:0:9d38:6abd:4bb:28b5:f5ff:fdf0\r\n   Li" \
+    "nk-local IPv6 Address . . . . . : fe80::4bb:28b5:f5ff:fdf0%14\r\n   Default Gateway . . . ." \
+    " . . . . . : ::\r\n"
+  end
+  subject { described_class.new }
+  context 'valid UTF-8 raw output' do
+    it 'decodes' do
+      expect(subject.decode(raw_output_with_bom)).to eq(expected)
+    end
+  end
+end


### PR DESCRIPTION
The `CommandOutputDecoder` slated for v2 from @sneal looks good to me and don't see why we cant benefit from it today as well as its spec.