### PR TITLE
Open a new shell if the current shell has been deleted

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,3 +10,13 @@ Style/Encoding:
 
 Metrics/LineLength:
   Max: 100
+
+Metrics/MethodLength:
+  Max: 20
+
+ClassLength:
+  Max: 250
+
+Metrics/AbcSize:
+  Max: 25
+  

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # WinRM Gem Changelog
 
+# 1.7.3
+- Open a new shell if the current shell has been deleted
+
 # 1.7.2
 - Fix regression where BOM appears in 2008R2 output and is not stripped
 

--- a/lib/winrm/command_executor.rb
+++ b/lib/winrm/command_executor.rb
@@ -98,8 +98,12 @@ module WinRM
       end
       result
     rescue WinRMWSManFault => e
+      # Fault code 2150858843 may be raised if the shell id that the command is sent on
+      # has been closed. One might see this on a target windows machine that has just
+      # been provisioned and restarted the winrm service at the end of its provisioning
+      # routine. If this hapens, we should give the command one more try.
       if e.fault_code == '2150858843' && (tries -= 1) > 0
-        service.logger.debug('[WinRM] openning new shell since the current one was deleted')
+        service.logger.debug('[WinRM] opening new shell since the current one was deleted')
         @shell = nil
         open
         retry

--- a/lib/winrm/version.rb
+++ b/lib/winrm/version.rb
@@ -3,5 +3,5 @@
 # WinRM module
 module WinRM
   # The version of the WinRM library
-  VERSION = '1.7.2'
+  VERSION = '1.7.3'
 end


### PR DESCRIPTION
Every now and again I receive the following exception running a command:
```
[WSMAN ERROR CODE: 2150858843]: <f:WSManFault Code='2150858843' Machine='xx.xx.xx.xx' xmlns:f='http://schemas.microsoft.com/wbem/wsman/1/wsmanfault'><f:Message>The request for the Windows Remote Shell with ShellId 5222A3E5-C6A5-4631-8CB7-545726F2C8AF failed because the shell was not found on the server. Possible causes are: the specified ShellId is incorrect or the shell no longer exists on the server. Provide the correct ShellId or create a new shell and retry the operation. </f:Message></f:WSManFault>
```

Usually this happens only after initially provisioning a VM and is not reproducible after the first exception.

I have recently run into a situation where this occurs consistently in Test-Kitchen tests where Test-Kitchen is running on an AWS hosted Jenkins slave and the test instance is in the same AWS network. Rerunning the test against the already provisioned test instance will proceed without error but will relibly raise again whenever I destroy the test instance and start another.

My theory he is that the winrm service is restarted on the test instance shortly after initially being provisioned. Because both the winrm target and the slave hostuing the winrm gem are in the same network. Getting an initial winrm session is relatively fast and occurs before the winrm restart. When winrm is restarted on the target while a winrm session is in progress, subsequent commands will fail with the above error.

This PR specifically rescues the above exception and will make a single retry attempt when it occurs after opening a new session.

I have tested this branch on my jenkins slave that consistently encounters this error and have validated that it fixes this problem and is able to gracefully recover.