### PR TITLE
WinRM certificate-based (password-less) authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ WinRM::WinRMWebService.new(endpoint, :ssl, :user => myuser, :pass => mypass, :ba
 WinRM::WinRMWebService.new(endpoint, :ssl, :user => myuser, :pass => mypass, :basic_auth_only => true, :ssl_peer_fingerprint => '6C04B1A997BA19454B0CD31C65D7020A6FC2669D')
 ```
 
+#Specifying a Cert, key and key password
+WinRM::WinRMWebService.new(target, :ssl, :client_cert => '../winrm.pem', :client_key => '../winrm.key', :key_pass => 'password', :no_ssl_peer_verification => true)
+
+
 ##### Create a self signed cert for WinRM
 You may want to create a self signed certificate for servicing https WinRM connections. You can use the following PowerShell script to create a cert and enable the WinRM HTTPS listener. Unless you are running windows server 2012 R2 or later, you must install makecert.exe from the Windows SDK, otherwise use `New-SelfSignedCertificate`.
 

--- a/README.md
+++ b/README.md
@@ -69,13 +69,14 @@ WinRM::WinRMWebService.new(endpoint, :ssl, :user => myuser, :pass => mypass, :ba
 
 # Verify against a known fingerprint
 WinRM::WinRMWebService.new(endpoint, :ssl, :user => myuser, :pass => mypass, :basic_auth_only => true, :ssl_peer_fingerprint => '6C04B1A997BA19454B0CD31C65D7020A6FC2669D')
-```
+
 
 #Specifying a Client Cert, key and (optional) key password for password-less authentication 
 WinRM::WinRMWebService.new(endpoint, :ssl, :client_cert => '/path/to/cert.pem', :client_key => '/path/to/key.key', :key_pass => 'password', :no_ssl_peer_verification => true)
 
 #Specifying a Client Cert object, key object and (optional) key password for password-less authentication 
 WinRM::WinRMWebService.new(endpoint, :ssl, :client_cert => <X509::Certificate object>, :client_key => <PKey::Pkey object, :key_pass => 'password', :no_ssl_peer_verification => true)  
+```
 
 ##### Create a self signed cert for WinRM
 You may want to create a self signed certificate for servicing https WinRM connections. You can use the following PowerShell script to create a cert and enable the WinRM HTTPS listener. Unless you are running windows server 2012 R2 or later, you must install makecert.exe from the Windows SDK, otherwise use `New-SelfSignedCertificate`.

--- a/README.md
+++ b/README.md
@@ -71,11 +71,10 @@ WinRM::WinRMWebService.new(endpoint, :ssl, :user => myuser, :pass => mypass, :ba
 WinRM::WinRMWebService.new(endpoint, :ssl, :user => myuser, :pass => mypass, :basic_auth_only => true, :ssl_peer_fingerprint => '6C04B1A997BA19454B0CD31C65D7020A6FC2669D')
 ```
 
-#Specifying a Cert, key and key password
+#Specifying a Client Cert, key and (optional) key password for password-less authentication 
 WinRM::WinRMWebService.new(target, :ssl, :client_cert => '/path/to/cert.pem', :client_key => '/path/to/key.key', :key_pass => 'password', :no_ssl_peer_verification => true)
 
-#Specifying a Cert object, key object and key password
-# the :client_cert and client_key can be an Openssl Objects
+## the :client_cert and client_key can be an Openssl Objects
 WinRM::WinRMWebService.new(target, :ssl, :client_cert => <X509::Certificate object>, :client_key => <PKey::Pkey object, :key_pass => 'password', :no_ssl_peer_verification => true)  
 
 ##### Create a self signed cert for WinRM

--- a/README.md
+++ b/README.md
@@ -72,10 +72,10 @@ WinRM::WinRMWebService.new(endpoint, :ssl, :user => myuser, :pass => mypass, :ba
 ```
 
 #Specifying a Client Cert, key and (optional) key password for password-less authentication 
-WinRM::WinRMWebService.new(target, :ssl, :client_cert => '/path/to/cert.pem', :client_key => '/path/to/key.key', :key_pass => 'password', :no_ssl_peer_verification => true)
+WinRM::WinRMWebService.new(endpoint, :ssl, :client_cert => '/path/to/cert.pem', :client_key => '/path/to/key.key', :key_pass => 'password', :no_ssl_peer_verification => true)
 
-## the :client_cert and client_key can be an Openssl Objects
-WinRM::WinRMWebService.new(target, :ssl, :client_cert => <X509::Certificate object>, :client_key => <PKey::Pkey object, :key_pass => 'password', :no_ssl_peer_verification => true)  
+#Specifying a Client Cert object, key object and (optional) key password for password-less authentication 
+WinRM::WinRMWebService.new(endpoint, :ssl, :client_cert => <X509::Certificate object>, :client_key => <PKey::Pkey object, :key_pass => 'password', :no_ssl_peer_verification => true)  
 
 ##### Create a self signed cert for WinRM
 You may want to create a self signed certificate for servicing https WinRM connections. You can use the following PowerShell script to create a cert and enable the WinRM HTTPS listener. Unless you are running windows server 2012 R2 or later, you must install makecert.exe from the Windows SDK, otherwise use `New-SelfSignedCertificate`.

--- a/README.md
+++ b/README.md
@@ -70,12 +70,11 @@ WinRM::WinRMWebService.new(endpoint, :ssl, :user => myuser, :pass => mypass, :ba
 # Verify against a known fingerprint
 WinRM::WinRMWebService.new(endpoint, :ssl, :user => myuser, :pass => mypass, :basic_auth_only => true, :ssl_peer_fingerprint => '6C04B1A997BA19454B0CD31C65D7020A6FC2669D')
 
-
-#Specifying a Client Cert, key and (optional) key password for password-less authentication 
+# Specifying a Client Cert, key and (optional) key password for password-less authentication 
 WinRM::WinRMWebService.new(endpoint, :ssl, :client_cert => '/path/to/cert.pem', :client_key => '/path/to/key.key', :key_pass => 'password', :no_ssl_peer_verification => true)
 
-#Specifying a Client Cert object, key object and (optional) key password for password-less authentication 
-WinRM::WinRMWebService.new(endpoint, :ssl, :client_cert => <X509::Certificate object>, :client_key => <PKey::Pkey object, :key_pass => 'password', :no_ssl_peer_verification => true)  
+# Specifying a Client Cert object, key object and (optional) key password for password-less authentication 
+WinRM::WinRMWebService.new(endpoint, :ssl, :client_cert => <X509::Certificate object>, :client_key => <PKey::Pkey object>, :key_pass => 'password', :no_ssl_peer_verification => true)  
 ```
 
 ##### Create a self signed cert for WinRM

--- a/README.md
+++ b/README.md
@@ -72,8 +72,11 @@ WinRM::WinRMWebService.new(endpoint, :ssl, :user => myuser, :pass => mypass, :ba
 ```
 
 #Specifying a Cert, key and key password
-WinRM::WinRMWebService.new(target, :ssl, :client_cert => '../winrm.pem', :client_key => '../winrm.key', :key_pass => 'password', :no_ssl_peer_verification => true)
+WinRM::WinRMWebService.new(target, :ssl, :client_cert => '/path/to/cert.pem', :client_key => '/path/to/key.key', :key_pass => 'password', :no_ssl_peer_verification => true)
 
+#Specifying a Cert object, key object and key password
+# the :client_cert and client_key can be an Openssl Objects
+WinRM::WinRMWebService.new(target, :ssl, :client_cert => <X509::Certificate object>, :client_key => <PKey::Pkey object, :key_pass => 'password', :no_ssl_peer_verification => true)  
 
 ##### Create a self signed cert for WinRM
 You may want to create a self signed certificate for servicing https WinRM connections. You can use the following PowerShell script to create a cert and enable the WinRM HTTPS listener. Unless you are running windows server 2012 R2 or later, you must install makecert.exe from the Windows SDK, otherwise use `New-SelfSignedCertificate`.

--- a/lib/winrm/http/transport.rb
+++ b/lib/winrm/http/transport.rb
@@ -244,10 +244,10 @@ module WinRM
 
     # Uses Certificate SSL to secure the transport
     class ClientCertAuthSSL < HttpTransport
-      def initialize(endpoint, ca_trust_path = nil, pem_file, key_file, opts)
+      def initialize(endpoint, ca_trust_path = nil, client_cert, client_key, opts)
         super(endpoint)
         @httpcli.ssl_config.set_trust_ca(ca_trust_path) unless ca_trust_path.nil?
-        @httpcli.ssl_config.set_client_cert_file("#{pem_file}","#{key_file}")
+        @httpcli.ssl_config.set_client_cert_file("#{client_cert}","#{client_key}")
         no_sspi_auth! if opts[:basic_auth_only]
         no_ssl_peer_verification! if opts[:no_ssl_peer_verification]
         @ssl_peer_fingerprint = opts[:ssl_peer_fingerprint] 

--- a/lib/winrm/http/transport.rb
+++ b/lib/winrm/http/transport.rb
@@ -44,10 +44,25 @@ module WinRM
         log_soap_message(message)
         hdr = { 'Content-Type' => 'application/soap+xml;charset=UTF-8',
                 'Content-Length' => message.bytesize }
+        unless @httpcli.ssl_config.client_cert.nil?
+          hdr.merge!({'Authorization' => 'http://schemas.dmtf.org/wbem/wsman/1/wsman/secprofile/https/mutual'})
+        end
+        
         resp = @httpcli.post(@endpoint, message, hdr)
         log_soap_message(resp.http_body.content)
         verify_ssl_fingerprint(resp.peer_cert)
         handler = WinRM::ResponseHandler.new(resp.http_body.content, resp.status)
+        handler.parse_to_xml
+      end
+
+      def send_request(message)
+        ssl_peer_fingerprint_verification!
+        log_soap_message(message)
+        
+        resp = @httpcli.post(@endpoint, message, hdr)
+        log_soap_message(resp.http_body.content)
+        verify_ssl_fingerprint(resp.peer_cert)
+        handler = WinRM::ResponseHandler.new(resp.http_body.conent, resp.status)
         handler.parse_to_xml
       end
 
@@ -251,24 +266,6 @@ module WinRM
         no_sspi_auth! if opts[:basic_auth_only]
         no_ssl_peer_verification! if opts[:no_ssl_peer_verification]
         @ssl_peer_fingerprint = opts[:ssl_peer_fingerprint] 
-      end
-
-    # Sends the SOAP payload to the WinRM service and returns the service's
-    # SOAP response. If an error occurrs an appropriate error is raised.
-    #
-    # @param [String] The XML SOAP message
-    # @returns [REXML::Document] The parsed response body
-      def send_request(message)
-        ssl_peer_fingerprint_verification!
-        log_soap_message(message)
-        hdr = { 'Content-Type' => 'application/soap+xml;charset=UTF-8',
-                'Content-Length' => message.length,
-                'Authorization' => 'http://schemas.dmtf.org/wbem/wsman/1/wsman/secprofile/https/mutual'}
-        resp = @httpcli.post(@endpoint, message, hdr)
-        log_soap_message(resp.http_body.content)
-        verify_ssl_fingerprint(resp.peer_cert)
-        handler = WinRM::ResponseHandler.new(resp.http_body.conent, resp.status)
-        handler.parse_to_xml
       end
     end
 

--- a/lib/winrm/http/transport.rb
+++ b/lib/winrm/http/transport.rb
@@ -46,7 +46,7 @@ module WinRM
                 'Content-Length' => message.bytesize }
         # We need to add this header if using Client Certificate authentication
         unless @httpcli.ssl_config.client_cert.nil?
-          hdr.merge!({'Authorization' => 'http://schemas.dmtf.org/wbem/wsman/1/wsman/secprofile/https/mutual'})
+          hdr['Authorization'] = 'http://schemas.dmtf.org/wbem/wsman/1/wsman/secprofile/https/mutual'
         end
 
         resp = @httpcli.post(@endpoint, message, hdr)
@@ -249,9 +249,9 @@ module WinRM
 
     # Uses Client Certificate to authenticate and SSL to secure the transport
     class ClientCertAuthSSL < HttpTransport
-      def initialize(endpoint, client_cert, client_key, key_pass,  opts)
+      def initialize(endpoint, client_cert, client_key, key_pass, opts)
         super(endpoint)
-        @httpcli.ssl_config.set_client_cert_file("#{client_cert}","#{client_key}", "#{key_pass}")
+        @httpcli.ssl_config.set_client_cert_file(client_cert, client_key, key_pass)
         @httpcli.www_auth.instance_variable_set('@authenticator', [])
         no_ssl_peer_verification! if opts[:no_ssl_peer_verification]
         @ssl_peer_fingerprint = opts[:ssl_peer_fingerprint]

--- a/lib/winrm/http/transport.rb
+++ b/lib/winrm/http/transport.rb
@@ -242,6 +242,18 @@ module WinRM
       end
     end
 
+    # Uses Certificate SSL to secure the transport
+    class ClientCertAuthSSL < HttpTransport
+      def initialize(endpoint, ca_trust_path = nil, pem_file, key_file, opts)
+        super(endpoint)
+        @httpcli.ssl_config.set_trust_ca(ca_trust_path) unless ca_trust_path.nil?
+        @httpcli.ssl_config.set_client_cert_file("#{pem_file}","#{key_file}")
+        no_sspi_auth! if opts[:basic_auth_only]
+        no_ssl_peer_verification! if opts[:no_ssl_peer_verification]
+        @ssl_peer_fingerprint = opts[:ssl_peer_fingerprint] 
+      end
+    end
+
     # Uses Kerberos/GSSAPI to authenticate and encrypt messages
     # rubocop:disable Metrics/ClassLength
     class HttpGSSAPI < HttpTransport

--- a/lib/winrm/http/transport.rb
+++ b/lib/winrm/http/transport.rb
@@ -244,7 +244,7 @@ module WinRM
 
     # Uses Certificate SSL to secure the transport
     class ClientCertAuthSSL < HttpTransport
-      def initialize(endpoint, client_cert, client_key, pass = nil, ca_trust_path = nil  opts)
+      def initialize(endpoint, client_cert, client_key, pass = nil, ca_trust_path = nil,  opts)
         super(endpoint)
         @httpcli.ssl_config.set_trust_ca(ca_trust_path) unless ca_trust_path.nil?
         @httpcli.ssl_config.set_client_cert_file("#{client_cert}","#{client_key}", "#{pass}")

--- a/lib/winrm/http/transport.rb
+++ b/lib/winrm/http/transport.rb
@@ -251,7 +251,7 @@ module WinRM
     class ClientCertAuthSSL < HttpTransport
       def initialize(endpoint, client_cert, client_key, key_pass,  opts)
         super(endpoint)
-        @httpcli.www_auth.instance_variable_get('@authenticator') = []
+        @httpcli.www_auth.instance_variable_set('@authenticator', [])
         @httpcli.ssl_config.set_client_cert_file("#{client_cert}","#{client_key}", "#{key_pass}")
         no_ssl_peer_verification! if opts[:no_ssl_peer_verification]
         @ssl_peer_fingerprint = opts[:ssl_peer_fingerprint]

--- a/lib/winrm/http/transport.rb
+++ b/lib/winrm/http/transport.rb
@@ -251,8 +251,8 @@ module WinRM
     class ClientCertAuthSSL < HttpTransport
       def initialize(endpoint, client_cert, client_key, key_pass,  opts)
         super(endpoint)
-        @httpcli.www_auth.instance_variable_set('@authenticator', [])
         @httpcli.ssl_config.set_client_cert_file("#{client_cert}","#{client_key}", "#{key_pass}")
+        @httpcli.www_auth.instance_variable_set('@authenticator', [])
         no_ssl_peer_verification! if opts[:no_ssl_peer_verification]
         @ssl_peer_fingerprint = opts[:ssl_peer_fingerprint]
         @httpcli.ssl_config.set_trust_ca(opts[:ca_trust_path]) if opts[:ca_trust_path]

--- a/lib/winrm/winrm_service.rb
+++ b/lib/winrm/winrm_service.rb
@@ -70,10 +70,10 @@ module WinRM
     end
 
     def init_ssl_transport(opts)
-      case 
+      case opts
       when opts[:basic_auth_only]
         HTTP::BasicAuthSSL.new(opts[:endpoint], opts[:user], opts[:pass], opts)
-      when opts[:certificate]
+      when opts[:client_cert]
         HTTP::ClientCertAuthSSL.new(opts[:endpoint], opts[:client_cert], opts[:client_key], opts)
       else
         HTTP::HttpNegotiate.new(opts[:endpoint], opts[:user], opts[:pass], opts)

--- a/lib/winrm/winrm_service.rb
+++ b/lib/winrm/winrm_service.rb
@@ -70,11 +70,14 @@ module WinRM
     end
 
     def init_ssl_transport(opts)
-      if opts[:basic_auth_only]
+      case 
+      when opts[:basic_auth_only]
         HTTP::BasicAuthSSL.new(opts[:endpoint], opts[:user], opts[:pass], opts)
+      when opts[:certificate]
+        HTTP::ClientCertAuthSSL.new(opts[:endpoint], opts[:client_cert], opts[:client_key], opts)
       else
         HTTP::HttpNegotiate.new(opts[:endpoint], opts[:user], opts[:pass], opts)
-      end
+      end        
     end
 
     # Operation timeout.

--- a/lib/winrm/winrm_service.rb
+++ b/lib/winrm/winrm_service.rb
@@ -73,7 +73,8 @@ module WinRM
       if opts[:basic_auth_only]
         HTTP::BasicAuthSSL.new(opts[:endpoint], opts[:user], opts[:pass], opts)
       elsif opts[:client_cert]
-        HTTP::ClientCertAuthSSL.new(opts[:endpoint], opts[:client_cert], opts[:client_key], opts[:key_pass], opts)
+        HTTP::ClientCertAuthSSL.new(opts[:endpoint], opts[:client_cert],
+                                    opts[:client_key], opts[:key_pass], opts)
       else
         HTTP::HttpNegotiate.new(opts[:endpoint], opts[:user], opts[:pass], opts)
       end

--- a/lib/winrm/winrm_service.rb
+++ b/lib/winrm/winrm_service.rb
@@ -70,14 +70,13 @@ module WinRM
     end
 
     def init_ssl_transport(opts)
-      case opts
-      when opts[:basic_auth_only]
+      if opts[:basic_auth_only]
         HTTP::BasicAuthSSL.new(opts[:endpoint], opts[:user], opts[:pass], opts)
-      when opts[:client_cert]
-        HTTP::ClientCertAuthSSL.new(opts[:endpoint], opts[:client_cert], opts[:client_key], opts)
+      elsif opts[:client_cert]
+        HTTP::ClientCertAuthSSL.new(opts[:endpoint], opts[:client_cert], opts[:client_key], opts[:key_pass], opts)
       else
         HTTP::HttpNegotiate.new(opts[:endpoint], opts[:user], opts[:pass], opts)
-      end        
+      end
     end
 
     # Operation timeout.


### PR DESCRIPTION
Added support for WinRM certificate-based (password-less) authentication. 
referenced: https://github.com/WinRb/WinRM/issues/199

