### PR TITLE
Warning cleanup.

### DIFF
--- a/lib/winrm/winrm_service.rb
+++ b/lib/winrm/winrm_service.rb
@@ -50,7 +50,7 @@ module WinRM
       configure_retries(opts)
       begin
         @xfer = send "init_#{transport}_transport", opts.merge({endpoint: endpoint})
-      rescue NoMethodError => e
+      rescue NoMethodError
         raise "Invalid transport '#{transport}' specified, expected: negotiate, kerberos, plaintext, ssl."
       end
     end
@@ -227,7 +227,7 @@ module WinRM
           env_body << Gyoku.xml(body)
         end
       end
-      resp = send_message(builder.target!)
+      send_message(builder.target!)
       true
     end
 
@@ -299,7 +299,7 @@ module WinRM
           env_body.tag!("#{NS_WIN_SHELL}:Signal", {'CommandId' => command_id}) { |cl| cl << Gyoku.xml(body) }
         end
       end
-      resp = send_message(builder.target!)
+      send_message(builder.target!)
       true
     end
 
@@ -316,7 +316,7 @@ module WinRM
         env.tag!('env:Body')
       end
 
-      resp = send_message(builder.target!)
+      send_message(builder.target!)
       logger.debug("[WinRM] remote shell #{shell_id} closed")
       true
     end

--- a/spec/response_handler_spec.rb
+++ b/spec/response_handler_spec.rb
@@ -2,42 +2,44 @@
 require 'winrm/http/response_handler'
 
 describe 'response handler', unit: true do
-  %w(v1, v2).each do |winrm_version|
-    let(:soap_fault) { File.read("spec/stubs/responses/soap_fault_#{winrm_version}.xml") }
-    let(:open_shell) { File.read("spec/stubs/responses/open_shell_#{winrm_version}.xml") }
+  %w(v1 v2).each do |winrm_version|
+    context "winrm_version #{winrm_version}" do
+      let(:soap_fault) { File.read("spec/stubs/responses/soap_fault_#{winrm_version}.xml") }
+      let(:open_shell) { File.read("spec/stubs/responses/open_shell_#{winrm_version}.xml") }
 
-    describe "successful 200 #{winrm_version} response" do
-      it 'returns an xml doc' do
-        handler = WinRM::ResponseHandler.new(open_shell, 200)
-        xml_doc = handler.parse_to_xml
-        expect(xml_doc).to be_instance_of(REXML::Document)
-        expect(xml_doc.to_s).to eq(REXML::Document.new(open_shell).to_s)
+      describe "successful 200 #{winrm_version} response" do
+        it 'returns an xml doc' do
+          handler = WinRM::ResponseHandler.new(open_shell, 200)
+          xml_doc = handler.parse_to_xml
+          expect(xml_doc).to be_instance_of(REXML::Document)
+          expect(xml_doc.to_s).to eq(REXML::Document.new(open_shell).to_s)
+        end
       end
-    end
 
-    describe "failed 500 #{winrm_version} response" do
-      it 'raises a WinRMHTTPTransportError' do
-        handler = WinRM::ResponseHandler.new('', 500)
-        expect { handler.parse_to_xml }.to raise_error(WinRM::WinRMHTTPTransportError)
+      describe "failed 500 #{winrm_version} response" do
+        it 'raises a WinRMHTTPTransportError' do
+          handler = WinRM::ResponseHandler.new('', 500)
+          expect { handler.parse_to_xml }.to raise_error(WinRM::WinRMHTTPTransportError)
+        end
       end
-    end
 
-    describe "failed 401 #{winrm_version} response" do
-      it 'raises a WinRMAuthorizationError' do
-        handler = WinRM::ResponseHandler.new('', 401)
-        expect { handler.parse_to_xml }.to raise_error(WinRM::WinRMAuthorizationError)
+      describe "failed 401 #{winrm_version} response" do
+        it 'raises a WinRMAuthorizationError' do
+          handler = WinRM::ResponseHandler.new('', 401)
+          expect { handler.parse_to_xml }.to raise_error(WinRM::WinRMAuthorizationError)
+        end
       end
-    end
 
-    describe "failed 400 #{winrm_version} response" do
-      it 'raises a WinRMWSManFault' do
-        handler = WinRM::ResponseHandler.new(soap_fault, 400)
-        begin
-          handler.parse_to_xml
-        rescue WinRM::WinRMWSManFault => e
-          expect(e.fault_code).to eq('2150858778')
-          expect(e.fault_description).to include(
-            'The specified class does not exist in the given namespace')
+      describe "failed 400 #{winrm_version} response" do
+        it 'raises a WinRMWSManFault' do
+          handler = WinRM::ResponseHandler.new(soap_fault, 400)
+          begin
+            handler.parse_to_xml
+          rescue WinRM::WinRMWSManFault => e
+            expect(e.fault_code).to eq('2150858778')
+            expect(e.fault_description).to include(
+              'The specified class does not exist in the given namespace')
+          end
         end
       end
     end


### PR DESCRIPTION
This cleans up most of the warnings I'm seeing with -w. The only one I didn't touch was the private attr_accessor warning, though it could be cleaned up, too, unless you just like it that way.

The specs were wrapped in a context to avoid redefinition warnings. There was one minor fix there as well - the removal of the explicit comma in the `%w[v1 v2]` code.

In other news, gyoku needs some cleanup as well...