### PR TITLE
bundler 1.12.0 is raising errors on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,7 +40,7 @@ install:
   - ps: Write-Host $env:PATH
   - ps: ruby --version
   - ps: gem --version
-  - ps: gem install bundler --quiet --no-ri --no-rdoc
+  - ps: gem install bundler -v 1.11.2 --quiet --no-ri --no-rdoc
   - ps: bundler --version
 
 build_script:


### PR DESCRIPTION
bundler 1.12.0 just released hours ago and its not playing nice with windows. I commented on this bug [here](https://github.com/bundler/bundler/issues/4472). Will revert this once this is fixed in bundler.