### PR TITLE
revert bundler pin

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,7 +40,7 @@ install:
   - ps: Write-Host $env:PATH
   - ps: ruby --version
   - ps: gem --version
-  - ps: gem install bundler -v 1.11.2 --quiet --no-ri --no-rdoc
+  - ps: gem install bundler --quiet --no-ri --no-rdoc
   - ps: bundler --version
 
 build_script:


### PR DESCRIPTION
bundler 1.12.1 is released and fixes the checksum error breaking appveyor builds.