### PR TITLE
http ceceive timeout should always be equal to 10 seconds greater than the winrm operation timeout

### DIFF
--- a/lib/winrm/http/transport.rb
+++ b/lib/winrm/http/transport.rb
@@ -22,15 +22,12 @@ module WinRM
     # This backend will maintain state for every WinRMWebService instance that is instantiated so it
     # is possible to use GSSAPI with Keep-Alive.
     class HttpTransport
-      # Set this to an unreasonable amount because WinRM has its own timeouts
-      DEFAULT_RECEIVE_TIMEOUT = 3600
 
       attr_reader :endpoint
 
       def initialize(endpoint)
         @endpoint = endpoint.is_a?(String) ? URI.parse(endpoint) : endpoint
         @httpcli = HTTPClient.new(agent_name: 'Ruby WinRM Client')
-        @httpcli.receive_timeout = DEFAULT_RECEIVE_TIMEOUT
         @logger = Logging.logger[self]
       end
 

--- a/lib/winrm/winrm_service.rb
+++ b/lib/winrm/winrm_service.rb
@@ -25,7 +25,7 @@ module WinRM
   # This is the main class that does the SOAP request/response logic. There are a few helper
   # classes, but pretty much everything comes through here first.
   class WinRMWebService
-    DEFAULT_TIMEOUT = 'PT60S'
+    DEFAULT_TIMEOUT = 60
     DEFAULT_MAX_ENV_SIZE = 153600
     DEFAULT_LOCALE = 'en-US'
 
@@ -42,7 +42,6 @@ module WinRM
     #   @see WinRM::HTTP::HttpSSL
     def initialize(endpoint, transport = :kerberos, opts = {})
       @endpoint = endpoint
-      @timeout = DEFAULT_TIMEOUT
       @max_env_sz = DEFAULT_MAX_ENV_SIZE
       @locale = DEFAULT_LOCALE
       @output_decoder = CommandOutputDecoder.new
@@ -50,6 +49,7 @@ module WinRM
       configure_retries(opts)
       begin
         @xfer = send "init_#{transport}_transport", opts.merge({endpoint: endpoint})
+        set_timeout(DEFAULT_TIMEOUT)
       rescue NoMethodError
         raise "Invalid transport '#{transport}' specified, expected: negotiate, kerberos, plaintext, ssl."
       end

--- a/spec/winrm_options_spec.rb
+++ b/spec/winrm_options_spec.rb
@@ -52,9 +52,9 @@ describe 'WinRM options', unit: true do
 
   context 'default' do
     describe '#receive_timeout' do
-      it 'should be 3600ms' do
+      it 'should be 70s' do
         transportclass = subject.instance_variable_get(:@xfer)
-        expect(transportclass.receive_timeout).to eql(3600)
+        expect(transportclass.receive_timeout).to eql(70)
       end
     end
     describe '#timeout' do


### PR DESCRIPTION
Inspired by https://discourse.chef.io/t/disconnected-while-in-bootstrap/8420 where it was noted that a winrm command hangs an hour if the connection is disrupted.

We make a point of setting the receive timeout to 10 seconds + the winrm operation timeout if the timeout is explicitly set. Otherwise it is set to an houir.

This PR makes the "10 second rule" consistent. In the event of a connection disruption, we should now fail much more quickly unles a long timeout is explicitly set.