### PR TITLE
Add WinRMWebServiceError Exception

### DIFF
--- a/lib/winrm/exceptions/exceptions.rb
+++ b/lib/winrm/exceptions/exceptions.rb
@@ -54,4 +54,13 @@ module WinRM
       super(msg + " (#{status_code}).")
     end
   end
+
+  # Error decrypting message
+  class WinRMWebServiceError < WinRMError
+    attr_reader :status_code
+
+    def initialize(msg)
+      super(msg)
+    end
+  end
 end


### PR DESCRIPTION
While writing some tests for our code using this Gem, the private winrm_decrypt method of WinRM::HTTP::HttpNegotiate raised the above error when it was unable to validate a decrypted message.  The exception was never defined in exceptions.rb, which of course causes another error.
This PR adds it.

@mwrock @sneal please review.  Thanks.