### PR TITLE
Do not swallow exit codes from executables

### DIFF
--- a/lib/winrm/shells/power_shell.rb
+++ b/lib/winrm/shells/power_shell.rb
@@ -98,6 +98,7 @@ module WinRM
 
       def send_command(command, _arguments)
         command_id = SecureRandom.uuid.to_s.upcase
+        command += "\r\nif (!$?) { if($LASTEXITCODE) { exit $LASTEXITCODE } else { exit 1 } }"
         message = PSRP::MessageFactory.create_pipeline_message(@runspace_id, command_id, command)
         fragmenter.fragment(message) do |fragment|
           command_args = [connection_opts, shell_id, command_id, fragment]

--- a/tests/integration/powershell_spec.rb
+++ b/tests/integration/powershell_spec.rb
@@ -13,6 +13,11 @@ describe 'winrm client powershell' do
     it { should have_no_stderr }
   end
 
+  describe 'ipconfig with invalid args' do
+    subject(:output) { @powershell.run('ipconfig blah') }
+    it { should have_exit_code 1 }
+  end
+
   describe 'throw' do
     subject(:output) { @powershell.run("throw 'an error occured'") }
     it { should have_exit_code 0 }


### PR DESCRIPTION
This catches `$LASTEXITCODE` and ensures it is included in `WinRM:Output.exitcode`