### PR TITLE
fix rwinrm command

### DIFF
--- a/bin/rwinrm
+++ b/bin/rwinrm
@@ -19,7 +19,6 @@
 
 $LOAD_PATH.push File.expand_path('../../lib', __FILE__)
 
-require 'readline'
 require 'io/console'
 require 'winrm'
 
@@ -39,11 +38,11 @@ def parse_options
 
   # Get the password
   print 'Password: '
-  options[:pass] = STDIN.noecho(&:gets).chomp
+  options[:password] = STDIN.noecho(&:gets).chomp
   puts
 
   # Set some defaults required by WinRM WS
-  options[:auth_type] = :plaintext
+  options[:transport] = :plaintext
   options[:basic_auth_only] = true
 
   options
@@ -54,31 +53,19 @@ rescue StandardError => e
 end
 
 def repl(options)
-  client = WinRM::WinRMWebService.new(
-    options[:endpoint],
-    options[:auth_type].to_sym,
-    options)
-
-  client.set_timeout(3600)
-  shell_id = client.open_shell
-  command_id = client.run_command(shell_id, 'cmd', "/K prompt [#{ARGV[0]}]$P$G")
-
-  read_thread = Thread.new do
-    client.get_command_output(shell_id, command_id) do |stdout, stderr|
-      STDOUT.write stdout
-      STDERR.write stderr
-    end
-  end
-  read_thread.abort_on_exception = true
-
-  while (buf = Readline.readline('', true))
-    if buf =~ /^exit/
-      read_thread.exit
-      client.cleanup_command(shell_id, command_id)
-      client.close_shell(shell_id)
-      exit 0
-    else
-      client.write_stdin(shell_id, command_id, "#{buf}\r\n")
+  client = WinRM::Connection.new(options)
+  client.shell('cmd') do |shell|
+    STDOUT.print '$ '
+    while (buf = Readline.readline('', true))
+      if buf =~ /^exit/
+        break
+      else
+        shell.run(buf) do |stdout, stderr|
+          STDOUT.print stdout
+          STDERR.print stderr
+        end
+        STDOUT.print '$ '
+      end
     end
   end
 rescue Interrupt


### PR DESCRIPTION
The `rwinrm` command used an API that appears to be absent. Update it to
use the current `WinRM::Connection` API.
