### PR TITLE
Fix rendering of powershell output with non ascii UTF-8 characters emitted from executables

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # WinRM Gem Changelog
 
+# 2.1.1
+- Fix rendering of powershell output with non ascii UTF-8 characters emitted from executables
+
 # 2.1.0
 - Expose shell options when creating a winrm shell
 

--- a/lib/winrm/psrp/message_data/pipeline_output.rb
+++ b/lib/winrm/psrp/message_data/pipeline_output.rb
@@ -33,7 +33,12 @@ module WinRM
             text = ''
             if node.text
               text << node.text.gsub(/_x(\h\h\h\h)_/) do
-                Regexp.last_match[1].hex.chr
+                decoded_text = Regexp.last_match[1].hex.chr.force_encoding('utf-8')
+                if decoded_text.respond_to?(:scrub)
+                  decoded_text.scrub
+                else
+                  decoded_text.encode('utf-16', invalid: :replace, undef: :replace).encode('utf-8')
+                end
               end.chomp
             end
             text << "\r\n"

--- a/lib/winrm/psrp/powershell_output_decoder.rb
+++ b/lib/winrm/psrp/powershell_output_decoder.rb
@@ -131,7 +131,12 @@ EOH
         return unless text
 
         text.gsub(/_x(\h\h\h\h)_/) do
-          Regexp.last_match[1].hex.chr
+          decoded_text = Regexp.last_match[1].hex.chr.force_encoding('utf-8')
+          if decoded_text.respond_to?(:scrub)
+            decoded_text.scrub
+          else
+            decoded_text.encode('utf-16', invalid: :replace, undef: :replace).encode('utf-8')
+          end
         end
       end
     end

--- a/lib/winrm/version.rb
+++ b/lib/winrm/version.rb
@@ -3,5 +3,5 @@
 # WinRM module
 module WinRM
   # The version of the WinRM library
-  VERSION = '2.1.0'.freeze
+  VERSION = '2.1.1'.freeze
 end


### PR DESCRIPTION
Addresses bug filed at https://github.com/test-kitchen/test-kitchen/issues/1170.

It appears that output emmited via powershell remoting from commandline executables (not powershell cmdlets) will be displayed using the native codepage of the running system and not necessarily UTF-8.

Having googled this extensively it appears that while you can adjust the console's encoding in a local powershell session, you cannot do so in a remote shell. That is unfortunate since while this fixes breakages converting to UTF-8 in ruby, the displayed text may not appear quite right. However I have confirmed that it does appear as it would in a normal powershell remoting session.

Sadly I could not produce a integration test to capture this. The bug was reported from a scenario running chef with a chef recipie that contained non ascii characters. I used:

```
file_path = File.join(Chef::Config[:file_cache_path], '中文文件名')

file file_path do
  action :create
end
```

I'd love to find a simple way to reproduce using only native bits but nothing I tried worked. I'm sure this is possible but the effort to value ratio is not proving this worth it.