### PR TITLE
Ignore error 2150858843 during command cleanup

### DIFF
--- a/lib/winrm/shells/base.rb
+++ b/lib/winrm/shells/base.rb
@@ -30,6 +30,7 @@ module WinRM
     class Base
       TOO_MANY_COMMANDS = '2150859174'.freeze
       ERROR_OPERATION_ABORTED = '995'.freeze
+      SHELL_NOT_FOUND = '2150858843'.freeze
 
       FAULTS_FOR_RESET = [
         '2150858843', # Shell has been closed
@@ -150,7 +151,7 @@ module WinRM
           command_id: command_id)
         transport.send_request(cleanup_msg.build)
       rescue WinRMWSManFault => e
-        raise unless e.fault_code == ERROR_OPERATION_ABORTED
+        raise unless [ERROR_OPERATION_ABORTED, SHELL_NOT_FOUND].include?(e.fault_code)
       rescue WinRMHTTPTransportError => t
         # dont let the cleanup raise so we dont lose any errors from the command
         logger.info("[WinRM] #{t.status_code} returned in cleanup with error: #{t.message}")

--- a/tests/spec/shells/base_spec.rb
+++ b/tests/spec/shells/base_spec.rb
@@ -117,6 +117,20 @@ describe DummyShell do
       subject.run(command, arguments)
     end
 
+    it 'does not error if shell is not present anymore' do
+      allow(SecureRandom).to receive(:uuid).and_return('uuid')
+      expect(transport).to receive(:send_request)
+        .with(
+          WinRM::WSMV::CleanupCommand.new(
+            connection_options,
+            shell_uri: nil,
+            shell_id: shell_id,
+            command_id: command_id
+          ).build
+        ).and_raise(WinRM::WinRMWSManFault.new('oops', '2150858843'))
+      subject.run(command, arguments)
+    end
+
     it 'opens a shell only once when shell is already open' do
       expect(subject).to receive(:open_shell).and_call_original.once
       subject.run(command, arguments)


### PR DESCRIPTION
It may happen that winrm shell disappear right after the execution of a
command (before its cleanup).

It can happen especially if winrm is stopped or restarted following the
execution of the command. For instance, using test-kitchen with ec2
boxes will trigger some winrm daemon configuration changes (creation
phase) which will lead to a restart of winrm process.

In this cases, we don't really care to cleanup correctly the command
environment (winrm shell is already missing, no need to destroy it)

Fixes #253

Change-Id: Ic2583f7e1a9df9b3a7fe1a33517209de97a96923
Signed-off-by: Grégoire Seux <g.seux@criteo.com>