### PR TITLE
Do full enumeration of run_wql requests

### DIFF
--- a/lib/winrm/connection.rb
+++ b/lib/winrm/connection.rb
@@ -18,6 +18,7 @@ require_relative 'connection_opts'
 require_relative 'http/transport_factory'
 require_relative 'shells/shell_factory'
 require_relative 'wsmv/wql_query'
+require_relative 'wsmv/wql_pull'
 
 module WinRM
   # WinRM connection used to establish a session with the remote WinRM service.
@@ -52,10 +53,11 @@ module WinRM
     # Executes a WQL query against the WinRM connection
     # @param wql [String] The wql query
     # @param namespace [String] namespace for query - default is root/cimv2/*
-    # @return [Hash] Hash representation of wql query response
-    def run_wql(wql, namespace = 'root/cimv2/*')
-      query = WinRM::WSMV::WqlQuery.new(@connection_opts, wql, namespace)
-      query.process_response(transport.send_request(query.build))
+    # @return [Hash] Hash representation of wql query response (Hash is empty if a block is given)
+    # @yeild [type, item] Yields the time name and item for every item
+    def run_wql(wql, namespace = 'root/cimv2/*', &block)
+      query = WinRM::WSMV::WqlQuery.new(transport, @connection_opts, wql, namespace)
+      query.process_response(transport.send_request(query.build), &block)
     end
 
     private

--- a/lib/winrm/wsmv/header.rb
+++ b/lib/winrm/wsmv/header.rb
@@ -185,6 +185,18 @@ module WinRM
         }
       end
 
+      def action_enumerate_pull
+        {
+          "#{SOAP::NS_ADDRESSING}:Action" =>
+          'http://schemas.xmlsoap.org/ws/2004/09/enumeration/Pull',
+          :attributes! => {
+            "#{SOAP::NS_ADDRESSING}:Action" => {
+              'mustUnderstand' => true
+            }
+          }
+        }
+      end
+
       def selector_shell_id(shell_id)
         {
           "#{SOAP::NS_WSMAN_DMTF}:SelectorSet" => {

--- a/lib/winrm/wsmv/wql_pull.rb
+++ b/lib/winrm/wsmv/wql_pull.rb
@@ -1,0 +1,56 @@
+# -*- encoding: utf-8 -*-
+
+require 'nori'
+require_relative 'base'
+
+module WinRM
+  module WSMV
+    # WSMV message to 'pull' rest of enumeration results from Windows via WQL
+    class WqlPull < Base
+      def initialize(session_opts, namespace, enumeration_context)
+        @session_opts = session_opts
+        @namespace = namespace
+        @enumeration_context = enumeration_context
+      end
+
+      def process_response(response)
+        parser = Nori.new(
+          parser: :rexml,
+          advanced_typecasting: false,
+          convert_tags_to: ->(tag) { tag.snakecase.to_sym },
+          strip_namespaces: true
+        )
+        parser.parse(response.to_s)[:envelope][:body]
+      end
+
+      protected
+
+      def create_header(header)
+        header << Gyoku.xml(wql_header)
+      end
+
+      def create_body(body)
+        body.tag!("#{NS_ENUM}:Pull") { |en| en << Gyoku.xml(wql_body) }
+      end
+
+      private
+
+      def wql_header
+        merge_headers(
+          shared_headers(@session_opts),
+          resource_uri_wmi(@namespace),
+          action_enumerate_pull
+        )
+      end
+
+      def wql_body
+        {
+          "#{NS_ENUM}:EnumerationContext" => @enumeration_context,
+          "#{NS_WSMAN_DMTF}:OptimizeEnumeration" => nil,
+          "#{NS_ENUM}:MaxElements" => '32000',
+          "#{NS_WSMAN_MSFT}:SessionId" => "uuid:#{@session_opts[:session_id]}"
+        }
+      end
+    end
+  end
+end

--- a/lib/winrm/wsmv/wql_query.rb
+++ b/lib/winrm/wsmv/wql_query.rb
@@ -41,7 +41,7 @@ module WinRM
         process_items hresp[:items], &block
 
         # Perform WS-Enum PULL's until we have all the elements
-        enumeration_context = hresp[:enumerate_response][:enumeration_context]
+        enumeration_context = hresp[:enumeration_context]
         until enumeration_context.nil?
           query = WqlPull.new(@session_opts, @namespace, enumeration_context)
           hresp = query.process_response(@transport.send_request(query.build))[:pull_response]

--- a/tests/integration/wql_spec.rb
+++ b/tests/integration/wql_spec.rb
@@ -13,4 +13,22 @@ describe 'winrm client wql' do
     expect(output_caption).to include('Microsoft')
     expect(output_caption).to include('Windows')
   end
+
+  it 'should query Win32_Process' do
+    output = @winrm.run_wql('select * from Win32_Process')
+    expect(output).to_not be_empty
+    process_count = output[:win32_process].count
+    expect(process_count).to be > 1
+    expect(output[:win32_process]).to all(include(:command_line))
+  end
+
+  it 'should query Win32_Process with block' do
+    count = 0
+    @winrm.run_wql('select * from Win32_Process') do |type, item|
+      expect(type).to eq(:win32_process)
+      expect(item).to include(:command_line)
+      count += 1
+    end
+    expect(count).to be > 1
+  end
 end

--- a/tests/spec/wsmv/wql_query_spec.rb
+++ b/tests/spec/wsmv/wql_query_spec.rb
@@ -4,7 +4,7 @@ require 'winrm/wsmv/wql_query'
 
 describe WinRM::WSMV::WqlQuery do
   context 'default session options' do
-    subject { described_class.new(default_connection_opts, 'SELECT * FROM Win32') }
+    subject { described_class.new(nil, default_connection_opts, 'SELECT * FROM Win32') }
     let(:xml) { subject.build }
     it 'creates a well formed message' do
       expect(xml).to include('<w:OperationTimeout>PT60S</w:OperationTimeout>')


### PR DESCRIPTION
Implement WSENUM pulls in order to get all responses from a wql query.
Allow a block to be passed to run_wql so that items can be processed as they're queried instead of building a large Array first. This will reduce memory usage and total run time for some large queries.

This fixes #168 