### PR TITLE
Ignore error 2150858843 during shell closing

### DIFF
--- a/lib/winrm/shells/base.rb
+++ b/lib/winrm/shells/base.rb
@@ -86,7 +86,11 @@ module WinRM
       # Closes the shell if one is open
       def close
         return unless shell_id
-        self.class.close_shell(connection_opts, transport, shell_id)
+        begin
+          self.class.close_shell(connection_opts, transport, shell_id)
+        rescue WinRMWSManFault => e
+          raise unless [ERROR_OPERATION_ABORTED, SHELL_NOT_FOUND].include?(e.fault_code)
+        end
         remove_finalizer
         @shell_id = nil
       end

--- a/tests/spec/shells/base_spec.rb
+++ b/tests/spec/shells/base_spec.rb
@@ -212,5 +212,14 @@ describe DummyShell do
       subject.close
       expect(subject.shell_id).to be(nil)
     end
+
+    context 'when shell was not found' do
+      it 'does not raise' do
+        subject.run(command, arguments)
+        expect(DummyShell).to receive(:close_shell)
+          .and_raise(WinRM::WinRMWSManFault.new('oops', '2150858843'))
+        expect { subject.close }.not_to raise_error
+      end
+    end
   end
 end


### PR DESCRIPTION
It is possible to get wsman error code 2150858843 when closing shell.
This patch protects against raising and ignore the error (after all the
shell is closed)