### PR TITLE
close and cleanup should retry on error and never raise net errors

### DIFF
--- a/lib/winrm/exceptions.rb
+++ b/lib/winrm/exceptions.rb
@@ -15,6 +15,15 @@
 # limitations under the License.
 
 module WinRM
+  NETWORK_EXCEPTIONS = lambda do
+    [
+      Errno::EACCES, Errno::EADDRINUSE, Errno::ECONNREFUSED, Errno::ETIMEDOUT,
+      Errno::ECONNRESET, Errno::ENETUNREACH, Errno::EHOSTUNREACH, ::WinRM::WinRMWSManFault,
+      ::WinRM::WinRMHTTPTransportError, ::WinRM::WinRMAuthorizationError,
+      HTTPClient::KeepAliveDisconnected, HTTPClient::ConnectTimeoutError
+    ].freeze
+  end
+
   # WinRM base class for errors
   class WinRMError < StandardError; end
 

--- a/lib/winrm/shells/base.rb
+++ b/lib/winrm/shells/base.rb
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 require_relative 'retryable'
+require_relative 'suppressible'
 require_relative '../http/transport'
 require_relative '../wsmv/cleanup_command'
 require_relative '../wsmv/close_shell'
@@ -31,14 +32,16 @@ module WinRM
       TOO_MANY_COMMANDS = '2150859174'.freeze
       ERROR_OPERATION_ABORTED = '995'.freeze
       SHELL_NOT_FOUND = '2150858843'.freeze
+      ERROR_READING_REGISTRY_KEY = '2147943418'.freeze
 
       FAULTS_FOR_RESET = [
-        '2150858843', # Shell has been closed
-        '2147943418', # Error reading registry key
+        SHELL_NOT_FOUND,
+        ERROR_READING_REGISTRY_KEY,
         TOO_MANY_COMMANDS, # Maximum commands per user exceeded
       ].freeze
 
       include Retryable
+      include Suppressible
 
       # Create a new Cmd shell
       # @param connection_opts [ConnectionOpts] The WinRM connection options
@@ -86,10 +89,10 @@ module WinRM
       # Closes the shell if one is open
       def close
         return unless shell_id
-        begin
-          self.class.close_shell(connection_opts, transport, shell_id)
-        rescue WinRMWSManFault => e
-          raise unless [ERROR_OPERATION_ABORTED, SHELL_NOT_FOUND].include?(e.fault_code)
+        suppressible do
+          retryable(connection_opts[:retry_limit], connection_opts[:retry_delay]) do
+            self.class.close_shell(connection_opts, transport, shell_id)
+          end
         end
         remove_finalizer
         @shell_id = nil
@@ -153,12 +156,11 @@ module WinRM
           shell_uri: shell_uri,
           shell_id: shell_id,
           command_id: command_id)
-        transport.send_request(cleanup_msg.build)
-      rescue WinRMWSManFault => e
-        raise unless [ERROR_OPERATION_ABORTED, SHELL_NOT_FOUND].include?(e.fault_code)
-      rescue WinRMHTTPTransportError => t
-        # dont let the cleanup raise so we dont lose any errors from the command
-        logger.info("[WinRM] #{t.status_code} returned in cleanup with error: #{t.message}")
+        suppressible do
+          retryable(connection_opts[:retry_limit], connection_opts[:retry_delay]) do
+            transport.send_request(cleanup_msg.build)
+          end
+        end
       end
 
       def open

--- a/lib/winrm/shells/suppressible.rb
+++ b/lib/winrm/shells/suppressible.rb
@@ -1,7 +1,6 @@
 # -*- encoding: utf-8 -*-
 #
-# Copyright 2016 Shawn Neal <sneal@sneal.net>
-# Copyright 2015 Matt Wrock <matt@mattwrock.com>
+# Copyright 2017 Matt Wrock <matt@mattwrock.com>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,17 +18,13 @@ require_relative '../exceptions'
 
 module WinRM
   module Shells
-    # Shell mixin for retrying an operation
-    module Retryable
-      # Retries the operation a specified number of times with a delay between
-      # @param retries [Integer] The number of times to retry
-      # @param delay [Integer] The number of seconds to wait between retry attempts
-      def retryable(retries, delay)
+    # Shell mixin for suppressing a network exception
+    module Suppressible
+      # performs an operation and suppresses any network exceptions
+      def suppressible
         yield
-      rescue *WinRM::NETWORK_EXCEPTIONS.call
-        raise unless (retries -= 1) > 0
-        sleep(delay)
-        retry
+      rescue *WinRM::NETWORK_EXCEPTIONS.call => e
+        logger.info("[WinRM] Exception suppressed: #{e.message}")
       end
     end
   end

--- a/tests/spec/shells/base_spec.rb
+++ b/tests/spec/shells/base_spec.rb
@@ -213,11 +213,11 @@ describe DummyShell do
       expect(subject.shell_id).to be(nil)
     end
 
-    context 'when shell was not found' do
+    context 'when connection is refused' do
       it 'does not raise' do
         subject.run(command, arguments)
         expect(DummyShell).to receive(:close_shell)
-          .and_raise(WinRM::WinRMWSManFault.new('oops', '2150858843'))
+          .and_raise(Errno::ECONNREFUSED.new)
         expect { subject.close }.not_to raise_error
       end
     end


### PR DESCRIPTION
This addresses the issues raised in [this comment](https://github.com/mitchellh/vagrant/pull/6922#issuecomment-293741172). Vagrant, and perhaps other applications, used to wrap shell commands in its own retryable block that would intercept errors raised in open, command execution, cleanup or shell close. Winrm now only wraps shell open in a retryable block. If a command requests a system reboot, its posible that the cleanup or shell close operations fail and raise an exception in the hosting application.

This PR wraps both cleanup and close in their own retryable block. Further, if all retries fail, it will not raise the error but will send it to the log output.

Signed-off-by: Matt Wrock <matt@mattwrock.com>