### PR TITLE
Updated retryable to add option list of faults to not retry.  Updated…

### DIFF
--- a/lib/winrm/shells/base.rb
+++ b/lib/winrm/shells/base.rb
@@ -157,7 +157,8 @@ module WinRM
           shell_id: shell_id,
           command_id: command_id)
         suppressible do
-          retryable(connection_opts[:retry_limit], connection_opts[:retry_delay]) do
+          retryable(connection_opts[:retry_limit], connection_opts[:retry_delay], 
+                    [ERROR_OPERATION_ABORTED, SHELL_NOT_FOUND]) do
             transport.send_request(cleanup_msg.build)
           end
         end

--- a/lib/winrm/shells/retryable.rb
+++ b/lib/winrm/shells/retryable.rb
@@ -24,13 +24,15 @@ module WinRM
       # Retries the operation a specified number of times with a delay between
       # @param retries [Integer] The number of times to retry
       # @param delay [Integer] The number of seconds to wait between retry attempts
-      def retryable(retries, delay)
+      # @param no_retry [Array of fault codes] Errors that are expected or unrecoverable. Don't retry
+      def retryable(retries, delay, no_retry = [])
         yield
-      rescue *WinRM::NETWORK_EXCEPTIONS.call
-        raise unless (retries -= 1) > 0
+      rescue *WinRM::NETWORK_EXCEPTIONS.call => e
+        raise if no_retry.include?(e.fault_code) || (retries -= 1) <= 0
         sleep(delay)
         retry
       end
     end
   end
 end
+


### PR DESCRIPTION
Powershell 2.0 seems to sometimes return the error SHELL_NOT_FOUND when
running the cleanup_command.  This can be demonstrated with a clean Win7
image install (plus Win Updates) and running rake integration.  The 
cleanup_command doesn't fail (because errors are suppressed), but it will 
retry several times making the tests take a very long time.  This was fixed 
with #254, however this logic to ignore SHELL_NOT_FOUND errors was removed 
with commit 7622781 and the bug was reintroduced.  This PR adds an optional
argument to the retryable mixin that allows you to specify errors that 
should not be retried, and sets [ERROR_OPERATION_ABORTED, SHELL_NOT_FOUND]
for cleanup_command so that these errors will immediately error as happened
before commit 7622781

rake integration without fix:
Finished in 12 minutes 19 seconds (files took 0.2391 seconds to load)
85 examples, 0 failures, 12 pending

rake integration with fix:
Finished in 38.25 seconds (files took 0.239 seconds to load)
85 examples, 0 failures, 12 pending