### PR TITLE
Use pack('S*') instead of .chr so full utf-16 can be supported

### DIFF
--- a/lib/winrm/psrp/message_data/pipeline_output.rb
+++ b/lib/winrm/psrp/message_data/pipeline_output.rb
@@ -31,7 +31,8 @@ module WinRM
             text = ''
             if node.text
               text << node.text.gsub(/(_x\h\h\h\h_)+/) do |match|
-                match.scan(/_x(\h\h\h\h)_/).flatten.map { |utf16| utf16.hex }.pack('S*').force_encoding('utf-16le').encode('utf-8')
+                match.scan(/_x(\h\h\h\h)_/).flatten.map(&:hex)
+                     .pack('S*').force_encoding('utf-16le').encode('utf-8')
               end.chomp
             end
             text << "\r\n"

--- a/lib/winrm/psrp/message_data/pipeline_output.rb
+++ b/lib/winrm/psrp/message_data/pipeline_output.rb
@@ -30,13 +30,8 @@ module WinRM
           doc.root.get_elements('//S').map do |node|
             text = ''
             if node.text
-              text << node.text.gsub(/_x(\h\h\h\h)_/) do
-                decoded_text = Regexp.last_match[1].hex.chr.force_encoding('utf-8')
-                if decoded_text.respond_to?(:scrub)
-                  decoded_text.scrub
-                else
-                  decoded_text.encode('utf-16', invalid: :replace, undef: :replace).encode('utf-8')
-                end
+              text << node.text.gsub(/(_x\h\h\h\h_)+/) do |match|
+                match.scan(/_x(\h\h\h\h)_/).flatten.map {|utf16| utf16.hex }.pack('S*').force_encoding('utf-16le').encode('utf-8')
               end.chomp
             end
             text << "\r\n"

--- a/lib/winrm/psrp/message_data/pipeline_output.rb
+++ b/lib/winrm/psrp/message_data/pipeline_output.rb
@@ -31,7 +31,7 @@ module WinRM
             text = ''
             if node.text
               text << node.text.gsub(/(_x\h\h\h\h_)+/) do |match|
-                match.scan(/_x(\h\h\h\h)_/).flatten.map {|utf16| utf16.hex }.pack('S*').force_encoding('utf-16le').encode('utf-8')
+                match.scan(/_x(\h\h\h\h)_/).flatten.map { |utf16| utf16.hex }.pack('S*').force_encoding('utf-16le').encode('utf-8')
               end.chomp
             end
             text << "\r\n"


### PR DESCRIPTION
carries #283 and fixes conflicts.