### PR TITLE
Use peer_cert for validation to prevent validating the signing cert

### DIFF
--- a/lib/winrm/http/transport.rb
+++ b/lib/winrm/http/transport.rb
@@ -74,7 +74,7 @@ module WinRM
         return unless @ssl_peer_fingerprint && !@ssl_peer_fingerprint_verified
 
         with_untrusted_ssl_connection do |connection|
-          connection_cert = connection.peer_cert_chain.last
+          connection_cert = connection.peer_cert
           verify_ssl_fingerprint(connection_cert)
         end
         @logger.info("initial ssl fingerprint #{@ssl_peer_fingerprint} verified\n")


### PR DESCRIPTION
The SSL peer fingerprint validation previously validated the last certificate in the certificate chain returned by the WinRM server rather than the peer cert explicitly. This worked in scenarios where self-signed certificates are used but fails when more than one certificate is listed in the chain.

This update fixes this behavior to ensure that peer fingerprint validation is always performed against the server certificate.