### PR TITLE
[POC] Replace erubis with erubi

### DIFF
--- a/lib/winrm/psrp/message_factory.rb
+++ b/lib/winrm/psrp/message_factory.rb
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'erubis'
+require 'erubi'
 require_relative 'message'
 
 module WinRM
@@ -66,7 +66,19 @@ module WinRM
             "#{File.dirname(__FILE__)}/#{template}.xml.erb"
           )
           template = File.read(template_path)
-          Erubis::Eruby.new(template).result(context)
+          case context
+          when Hash
+            b = binding
+            locals = context.collect { |k, _| "#{k} = context[#{k.inspect}]; " }
+            b.eval(locals.join)
+          when Binding
+            b = context
+          when NilClass
+            b = binding
+          else
+            raise ArgumentError
+          end
+          b.eval(Erubi::Engine.new(template).src)
         end
       end
     end

--- a/winrm.gemspec
+++ b/winrm.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.executables = ['rwinrm']
   s.required_ruby_version = '>= 2.2.0'
   s.add_runtime_dependency 'builder', '>= 2.1.2'
-  s.add_runtime_dependency 'erubis', '~> 2.7'
+  s.add_runtime_dependency 'erubi', '~> 1.8'
   s.add_runtime_dependency 'gssapi', '~> 1.2'
   s.add_runtime_dependency 'gyoku', '~> 1.0'
   s.add_runtime_dependency 'httpclient', '~> 2.2', '>= 2.2.0.2'


### PR DESCRIPTION
I'm opening this pull request to see if this is something that would be ultimately accepted.  It looks like people have been moving off of erubis because it's mostly unmaintained and more complicated.

This seems to have been influenced greatly by rails:
https://github.com/rails/rails/pull/27757

We needed to implement the result method from erubis:
https://www.rubydoc.info/gems/erubis/2.7.0/Erubis/RubyEvaluator#result-instance_method

I got the tests to pass but I have no idea if I covered everything.