### PR TITLE
Fix Kerberos Decryption Corruption

### DIFF
--- a/lib/winrm/http/transport.rb
+++ b/lib/winrm/http/transport.rb
@@ -435,7 +435,7 @@ module WinRM
         str.sub!(%r{^.*Content-Type: application\/octet-stream\r\n(.*)--Encrypted.*$}m, '\1')
 
         len = str.unpack('L').first
-        iov_data = str.unpack("LA#{len}A*")
+        iov_data = str.unpack("La#{len}a*")
         iov0[:buffer].value = iov_data[1]
         iov1[:buffer].value = iov_data[2]
 


### PR DESCRIPTION
 - The winrm_decrypt method, which appears to be a near copy of the
   original GSSAPI gem helpers from

   https://github.com/zenchild/gssapi/blob/master/examples

   includes a fatal bug.

   Specifically the original code at line
   https://github.com/zenchild/gssapi/blob/master/examples/gss_iov_helpers.rb#L50

   When breaking apart the given binary string response into length of header,
   header and payload - the incorrect value is given to Rubys unpack method.

   https://ruby-doc.org/core-2.3.0/String.html#method-i-unpack

   The directive 'A' is used:

   A | String | arbitrary binary string (remove trailing nulls and ASCII spaces)

   Since the given string is encrypted binary data, 'A' is the wrong directive
   given it performs removals.

   Instead, the directive 'a' should be used as it leaves all bytes intact:

   a | String | arbitrary binary string

 - Without this change, intermittent failures will occur as the decrypted SOAP
   messages will contain almost valid XML, but usually end with corrupt binary
   strings at the end of otherwise valid UTF-8 like

   </s:Body></s\xB5f\xAF\x9B\xE5\x9B\xE9\xFE\xBB

   These failures occur frequently enough to make Kerberos usage completely
   unreliable