### PR TITLE
ErrorRecord.invocation_info crash if <Nil N="InvocationInfo" />

### DIFF
--- a/lib/winrm/psrp/message_data/error_record.rb
+++ b/lib/winrm/psrp/message_data/error_record.rb
@@ -48,6 +48,8 @@ module WinRM
 
         def property_hash(prop_name)
           prop_nodes = REXML::XPath.first(doc, "//*[@N='#{prop_name}']/Props")
+          return {} if prop_nodes.nil?
+
           prop_nodes.elements.each_with_object({}) do |node, props|
             name = node.attributes['N']
             props[underscore(name).to_sym] = node.text if node.text


### PR DESCRIPTION
A fix for #309. Not sure if you want to fix it this way, but this avoids the crash for me.