### PR TITLE
Fix typo in error message

### DIFF
--- a/lib/winrm/shells/power_shell.rb
+++ b/lib/winrm/shells/power_shell.rb
@@ -153,7 +153,7 @@ module WinRM
           resp_doc = transport.send_request(msg)
           REXML::XPath.first(resp_doc, "//*[local-name() = 'MaxEnvelopeSizekb']").text.to_i
         ensure
-          logger.debug("[WinRM] Endpoint doesn't support config request for MaxEnvelopsizekb")
+          logger.debug("[WinRM] Endpoint doesn't support config request for MaxEnvelopeSizekb")
         end
         # rubocop:enable Layout/RescueEnsureAlignment
       end


### PR DESCRIPTION
Fix a typo in parameter and match the case from the [official docs](https://docs.microsoft.com/en-us/powershell/module/microsoft.wsman.management/set-wsmaninstance?view=powershell-7#examples).

chef/chef#9909

Signed-off-by: Pete Higgins <pete@peterhiggins.org>