### PR TITLE
Optimize our requires

### DIFF
--- a/lib/winrm/http/response_handler.rb
+++ b/lib/winrm/http/response_handler.rb
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'rexml/document'
+require 'rexml/document' unless defined?(REXML::Document)
 require_relative '../wsmv/soap'
 
 module WinRM

--- a/lib/winrm/psrp/message_data/pipeline_output.rb
+++ b/lib/winrm/psrp/message_data/pipeline_output.rb
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'rexml/document'
+require 'rexml/document' unless defined?(REXML::Document)
 
 module WinRM
   module PSRP

--- a/lib/winrm/psrp/powershell_output_decoder.rb
+++ b/lib/winrm/psrp/powershell_output_decoder.rb
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'base64'
+require 'base64' unless defined?(Base64)
 require_relative 'message'
 require_relative 'message_data/pipeline_state'
 

--- a/lib/winrm/shells/power_shell.rb
+++ b/lib/winrm/shells/power_shell.rb
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'securerandom'
+require 'securerandom' unless defined?(SecureRandom)
 require_relative 'base'
 require_relative '../psrp/message_fragmenter'
 require_relative '../psrp/receive_response_reader'


### PR DESCRIPTION
Avoid requiring things that are already defined. Rubygems is very slow at traversing the filesystem.

Signed-off-by: Tim Smith <tsmith@chef.io>