### PR TITLE
do not cleanup command if there is no shell

### DIFF
--- a/lib/winrm/shells/base.rb
+++ b/lib/winrm/shells/base.rb
@@ -147,6 +147,7 @@ module WinRM
       end
 
       def cleanup_command(command_id)
+        return unless shell_id
         logger.debug("[WinRM] cleaning up command_id: #{command_id} on shell_id #{shell_id}")
         cleanup_msg = WinRM::WSMV::CleanupCommand.new(
           connection_opts,


### PR DESCRIPTION
This addresses a scenario introduced in #315 where another thread calls `close` on a shell while a long running command is running and then when the thread running the command experiences an exception when it attempts to send a cleanup/termination command on a closed shell.

This PR addresses the exception but does not truly fix the above issue since it still does not allow a way to send a terminate message on an existing command. We would need to do some deeper refactoring to support that.

It's important to note here that closing a shell while a command is running may cause that command to run indefinitely on the remote machine.

Signed-off-by: mwrock <matt@mattwrock.com>