### PR TITLE
Add a cert_store option

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ The `:ssl` transport establishes a connection to the winrm endpoint over a secur
 * `:no_ssl_peer_verification` - when set to `true` ssl certificate validation is not performed. With a self signed cert, its a match made in heaven!
 * `:ssl_peer_fingerprint` - when this is provided, normal certificate validation is skipped and instead the given fingerprint is matched against the certificate of the endpoint for verification.
 * `:ca_trust_path` - the path to a certificate `.pem` file to trust. Its similar to the `:ssl_peer_fingerprint` but contains the entire certificate to trust.
+* `:cert_store` - an OpenSSL::X509::X509::Store object used for certificate verification.
 
 ### `:kerberos`
 ```ruby

--- a/lib/winrm/http/transport.rb
+++ b/lib/winrm/http/transport.rb
@@ -161,6 +161,7 @@ module WinRM
         no_ssl_peer_verification! if opts[:no_ssl_peer_verification]
         @ssl_peer_fingerprint = opts[:ssl_peer_fingerprint]
         @httpcli.ssl_config.set_trust_ca(opts[:ca_trust_path]) if opts[:ca_trust_path]
+        @httpcli.ssl_config.cert_store = opts[:cert_store] if opts[:cert_store]
       end
 
       def send_request(message)
@@ -268,6 +269,7 @@ module WinRM
         no_ssl_peer_verification! if opts[:no_ssl_peer_verification]
         @ssl_peer_fingerprint = opts[:ssl_peer_fingerprint]
         @httpcli.ssl_config.set_trust_ca(opts[:ca_trust_path]) if opts[:ca_trust_path]
+        @httpcli.ssl_config.cert_store = opts[:cert_store] if opts[:cert_store]
       end
     end
 
@@ -280,6 +282,7 @@ module WinRM
         no_ssl_peer_verification! if opts[:no_ssl_peer_verification]
         @ssl_peer_fingerprint = opts[:ssl_peer_fingerprint]
         @httpcli.ssl_config.set_trust_ca(opts[:ca_trust_path]) if opts[:ca_trust_path]
+        @httpcli.ssl_config.cert_store = opts[:cert_store] if opts[:cert_store]
       end
     end
 


### PR DESCRIPTION
Hi,
It would be great to be able to use the gem with for instance an in-memory certificate instead of a file!
This PR add the option to use a `cert_store` option where it is currently possible to specify a `ca_trust_path` (https://rubydoc.info/gems/httpclient/HTTPClient/SSLConfig)
I would love to have your feedback on this,
Best regards,
Sulidi