### PR TITLE
Add rexml as an explicit dependency for Ruby 3.x

### DIFF
--- a/winrm.gemspec
+++ b/winrm.gemspec
@@ -37,10 +37,10 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'httpclient', '~> 2.2', '>= 2.2.0.2'
   s.add_runtime_dependency 'logging', ['>= 1.6.1', '< 3.0']
   s.add_runtime_dependency 'nori', '~> 2.0'
+  s.add_runtime_dependency 'rexml', '~> 3.0'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rake', '>= 10.3', '< 13'
   s.add_development_dependency 'rb-readline'
-  s.add_development_dependency 'rexml'
   s.add_development_dependency 'rspec', '~> 3.2'
   s.add_development_dependency 'rubocop', '~> 0.51.0'
   s.add_runtime_dependency 'rubyntlm', '~> 0.6.0', '>= 0.6.3'


### PR DESCRIPTION
* rexml was removed as a default gem from Ruby 3.x, so we need to add it as an explicit dependency.
* Restrict the rexml version family to 3.0+. Ruby 2.6 shipped with rexml-3.1.9.1 so this should be compatible.