### PR TITLE
Adding user-agent option

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ There are various connection options you can specify upon initializing a WinRM c
 * `:operation_timeout` - The maximum amount of time to wait for a response from the endpoint. This defaults to 60 seconds. Note that this will not "timeout" commands that exceed this amount of time to process, it just requires the endpoint to report the status of the command before the given amount of time passes.
 * `:receive_timeout` - The amount of time given to the underlying HTTP connection to respond before timing out. The defaults to 10 seconds longer than the `:operation_timeout`.
 * `:retry_limit` - the maximum number of times to retry opening a shell after failure. This defaults to 3.
+* `:user_agent` - the user-agent used in the http connection, default to 'Ruby WinRM Client'
 * `:retry_delay` - the amount of time to wait between retries and defaults to 10 seconds
 * `:user` - username used to authenticate over the `:transport`
 * `:password` - password used to authenticate over the `:transport`

--- a/lib/winrm/connection_opts.rb
+++ b/lib/winrm/connection_opts.rb
@@ -23,6 +23,7 @@ module WinRM
     DEFAULT_LOCALE = 'en-US'.freeze
     DEFAULT_RETRY_DELAY = 10
     DEFAULT_RETRY_LIMIT = 3
+    DEFAULT_USER_AGENT = 'Ruby WinRM Client'.freeze
 
     class << self
       def create_with_defaults(overrides)
@@ -51,6 +52,7 @@ module WinRM
         config[:receive_timeout] = DEFAULT_RECEIVE_TIMEOUT
         config[:retry_delay] = DEFAULT_RETRY_DELAY
         config[:retry_limit] = DEFAULT_RETRY_LIMIT
+        config[:user_agent] = DEFAULT_USER_AGENT
         config
       end
     end

--- a/lib/winrm/http/transport.rb
+++ b/lib/winrm/http/transport.rb
@@ -25,9 +25,10 @@ module WinRM
 
       def initialize(endpoint, options)
         @endpoint = endpoint.is_a?(String) ? URI.parse(endpoint) : endpoint
-        @httpcli = HTTPClient.new(agent_name: 'Ruby WinRM Client')
+        @httpcli = HTTPClient.new()
         @logger = Logging.logger[self]
         @httpcli.receive_timeout = options[:receive_timeout]
+        @httpcli.default_header = {'User-Agent': options[:user_agent]}
       end
 
       # Sends the SOAP payload to the WinRM service and returns the service's

--- a/lib/winrm/http/transport.rb
+++ b/lib/winrm/http/transport.rb
@@ -25,10 +25,10 @@ module WinRM
 
       def initialize(endpoint, options)
         @endpoint = endpoint.is_a?(String) ? URI.parse(endpoint) : endpoint
-        @httpcli = HTTPClient.new()
+        @httpcli = HTTPClient.new
         @logger = Logging.logger[self]
         @httpcli.receive_timeout = options[:receive_timeout]
-        @httpcli.default_header = {'User-Agent': options[:user_agent]}
+        @httpcli.default_header = { 'User-Agent': options[:user_agent] }
       end
 
       # Sends the SOAP payload to the WinRM service and returns the service's


### PR DESCRIPTION
Fix the issue #336.
It should be noted that there is a slight change regarding the `User-Agent` with this PR. Before the changement the User-Agent would have been:

```
User-Agent: Ruby WinRM Client (HTTPClient_LIB_VERSION, ruby VERSION (DATE_VERSION))
```

After this PR, the `User-Agent` would simply be: `Ruby WinRM Client`.

As I am nowhere near the skill of a ruby developer, let me know if my code can be improved (I have run the required tests).