### PR TITLE
Create thread in shell finalizer

### DIFF
--- a/lib/winrm/shells/base.rb
+++ b/lib/winrm/shells/base.rb
@@ -183,6 +183,10 @@ module WinRM
       def remove_finalizer
         ObjectSpace.undefine_finalizer(self)
       end
+
+      def self.finalize(connection_opts, transport, shell_id)
+        proc { Thread.new { close_shell(connection_opts, transport, shell_id) } }
+      end
     end
   end
 end

--- a/lib/winrm/shells/cmd.rb
+++ b/lib/winrm/shells/cmd.rb
@@ -20,10 +20,6 @@ module WinRM
     class Cmd < Base
       include WinRM::WSMV::SOAP
       class << self
-        def finalize(connection_opts, transport, shell_id)
-          proc { Cmd.close_shell(connection_opts, transport, shell_id) }
-        end
-
         def close_shell(connection_opts, transport, shell_id)
           msg = WinRM::WSMV::CloseShell.new(connection_opts, shell_id: shell_id)
           transport.send_request(msg.build)

--- a/lib/winrm/shells/power_shell.rb
+++ b/lib/winrm/shells/power_shell.rb
@@ -29,10 +29,6 @@ module WinRM
       include WinRM::WSMV::SOAP
 
       class << self
-        def finalize(connection_opts, transport, shell_id)
-          proc { Powershell.close_shell(connection_opts, transport, shell_id) }
-        end
-
         def close_shell(connection_opts, transport, shell_id)
           msg = WinRM::WSMV::CloseShell.new(
             connection_opts,


### PR DESCRIPTION
The following call chain was observed:
1. `Cmd.close_shell` or `Powershell.close_shell`
2. `HttpTransport#send_request`
3. `HTTPClient#post`

And `HTTPClient#post` internally calls `Mutex#synchronize`, which raises `ThreadError` if called from a finalizer. Although the behavior is not documented, it makes sense as a finalizer can be called in a block passed to `Mutex#synchronize`, and calling `Mutex#syncrhonize` again for the same mutex in the finalizer can lead to deadlock.

Create a thread in the shell finalizer and do everything in the thread to avoid problems with `Mutex#synchronize`.