### PR TITLE
Added fix for thread error

### DIFF
--- a/lib/winrm/shells/power_shell.rb
+++ b/lib/winrm/shells/power_shell.rb
@@ -34,12 +34,16 @@ module WinRM
         end
 
         def close_shell(connection_opts, transport, shell_id)
+          return false unless Thread.current.alive?
+          Thread.current.wakeup if Thread.current.status =~ /sleep/
           msg = WinRM::WSMV::CloseShell.new(
             connection_opts,
             shell_id: shell_id,
             shell_uri: WinRM::WSMV::Header::RESOURCE_URI_POWERSHELL
           )
           transport.send_request(msg.build)
+        rescue ThreadError => e
+          logger.debug("#{e.message}")
         end
       end
 


### PR DESCRIPTION
Fixed the below thread error coming up on windows nodes on the execution of the kitchen verify and knife commands.

`Test Summary: 0 successful, 0 failures, 1 skipped
       Finished verifying <default-windows-2022-base1> (0m18.89s).
-----> Test Kitchen is finished. (0m35.20s)
/opt/chef-workstation/bin/kitchen: warning: Exception in finalizer #<Proc:0x000000011bf58a18 /opt/chef-workstation/embedded/lib/ruby/gems/3.1.0/gems/winrm-2.3.6/lib/winrm/shells/power_shell.rb:33>
/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0/gems/logging-2.3.1/lib/logging/diagnostic_context.rb:471:in `new': can't alloc thread (ThreadError)
	from /opt/chef-workstation/embedded/lib/ruby/gems/3.1.0/gems/logging-2.3.1/lib/logging/diagnostic_context.rb:471:in `create_with_logging_context'
	from /opt/chef-workstation/embedded/lib/ruby/gems/3.1.0/gems/logging-2.3.1/lib/logging/diagnostic_context.rb:436:in `new'
	from /opt/chef-workstation/embedded/lib/ruby/gems/3.1.0/gems/timeout-0.3.2/lib/timeout.rb:101:in `create_timeout_thread'
	from /opt/chef-workstation/embedded/lib/ruby/gems/3.1.0/gems/timeout-0.3.2/lib/timeout.rb:134:in `block in ensure_timeout_thread_created'
	from /opt/chef-workstation/embedded/lib/ruby/gems/3.1.0/gems/timeout-0.3.2/lib/timeout.rb:132:in `synchronize'
	from /opt/chef-workstation/embedded/lib/ruby/gems/3.1.0/gems/timeout-0.3.2/lib/timeout.rb:132:in `ensure_timeout_thread_created'
	from /opt/chef-workstation/embedded/lib/ruby/gems/3.1.0/gems/timeout-0.3.2/lib/timeout.rb:181:in `timeout'
	from /opt/chef-workstation/embedded/lib/ruby/gems/3.1.0/gems/httpclient-2.8.3/lib/httpclient/session.rb:515:in `query'
	from /opt/chef-workstation/embedded/lib/ruby/gems/3.1.0/gems/httpclient-2.8.3/lib/httpclient/session.rb:177:in `query'
	from /opt/chef-workstation/embedded/lib/ruby/gems/3.1.0/gems/httpclient-2.8.3/lib/httpclient.rb:1242:in `do_get_block'
	from /opt/chef-workstation/embedded/lib/ruby/gems/3.1.0/gems/httpclient-2.8.3/lib/httpclient.rb:1019:in `block in do_request'
	from /opt/chef-workstation/embedded/lib/ruby/gems/3.1.0/gems/httpclient-2.8.3/lib/httpclient.rb:1133:in `protect_keep_alive_disconnected'
	from /opt/chef-workstation/embedded/lib/ruby/gems/3.1.0/gems/httpclient-2.8.3/lib/httpclient.rb:1014:in `do_request'
	from /opt/chef-workstation/embedded/lib/ruby/gems/3.1.0/gems/httpclient-2.8.3/lib/httpclient.rb:856:in `request'
	from /opt/chef-workstation/embedded/lib/ruby/gems/3.1.0/gems/httpclient-2.8.3/lib/httpclient.rb:765:in `post'
	from /opt/chef-workstation/embedded/lib/ruby/gems/3.1.0/gems/winrm-2.3.6/lib/winrm/http/transport.rb:176:in `send_request'
	from /opt/chef-workstation/embedded/lib/ruby/gems/3.1.0/gems/winrm-2.3.6/lib/winrm/shells/power_shell.rb:42:in `close_shell'
	from /opt/chef-workstation/embedded/lib/ruby/gems/3.1.0/gems/winrm-2.3.6/lib/winrm/shells/power_shell.rb:33:in `block in finalize'`

Issue - https://github.com/chef/chef-workstation/issues/3073

