### PR TITLE
Fix snakecase `NoMethodError`

### DIFF
--- a/lib/winrm/psrp/message_data/base.rb
+++ b/lib/winrm/psrp/message_data/base.rb
@@ -35,7 +35,7 @@ module WinRM
             parser = Nori.new(
               parser: :rexml,
               advanced_typecasting: false,
-              convert_tags_to: ->(tag) { tag.snakecase.to_sym },
+              convert_tags_to: ->(tag) { Nori::StringUtils.snakecase(tag).to_sym },
               strip_namespaces: true
             )
             parser.parse(raw)[:obj][:ms]

--- a/lib/winrm/wsmv/wql_pull.rb
+++ b/lib/winrm/wsmv/wql_pull.rb
@@ -15,7 +15,7 @@ module WinRM
         parser = Nori.new(
           parser: :rexml,
           advanced_typecasting: false,
-          convert_tags_to: ->(tag) { tag.snakecase.to_sym },
+          convert_tags_to: ->(tag) { Nori::StringUtils.snakecase(tag).to_sym },
           strip_namespaces: true
         )
         parser.parse(response.to_s)[:envelope][:body]

--- a/lib/winrm/wsmv/wql_query.rb
+++ b/lib/winrm/wsmv/wql_query.rb
@@ -30,7 +30,7 @@ module WinRM
         parser = Nori.new(
           parser: :rexml,
           advanced_typecasting: false,
-          convert_tags_to: ->(tag) { tag.snakecase.to_sym },
+          convert_tags_to: ->(tag) { Nori::StringUtils.snakecase(tag).to_sym },
           strip_namespaces: true
         )
         @items = Hash.new { |h, k| h[k] = [] }

--- a/winrm.gemspec
+++ b/winrm.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'gyoku', '~> 1.0'
   s.add_runtime_dependency 'httpclient', '~> 2.2', '>= 2.2.0.2'
   s.add_runtime_dependency 'logging', ['>= 1.6.1', '< 3.0']
-  s.add_runtime_dependency 'nori', '~> 2.0'
+  s.add_runtime_dependency 'nori', '~> 2.0', '>= 2.7.1'
   s.add_runtime_dependency 'rexml', '~> 3.0'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rake', '>= 10.3', '< 13'


### PR DESCRIPTION
This PR fixes #346.

I've added also a constraint on `nori` minimum version, if this is unwanted, then we could check its version at runtime and behave accordingly.

Checking `Gem.loaded_specs['nori'].version < Gem::Version.create('2.7.1')`, and if the statement is true, use directly `snakecase` fn.