### PR TITLE
Rename object_id to message_id

### DIFF
--- a/lib/winrm/psrp/fragment.rb
+++ b/lib/winrm/psrp/fragment.rb
@@ -19,27 +19,27 @@ module WinRM
     # PowerShell Remoting Protocol message fragment.
     class Fragment
       # Creates a new PSRP message fragment
-      # @param object_id [Integer] The id of the fragmented message.
+      # @param message_id [Integer] The id of the fragmented message.
       # @param blob [Array] Array of fragmented bytes.
       # @param fragment_id [Integer] The id of this fragment
       # @param start_fragment [Boolean] If the fragment is the first fragment
       # @param end_fragment [Boolean] If the fragment is the last fragment
-      def initialize(object_id, blob, fragment_id = 0, start_fragment = true, end_fragment = true)
-        @object_id = object_id
+      def initialize(message_id, blob, fragment_id = 0, start_fragment = true, end_fragment = true)
+        @message_id = message_id
         @blob = blob
         @fragment_id = fragment_id
         @start_fragment = start_fragment
         @end_fragment = end_fragment
       end
 
-      attr_reader :object_id, :fragment_id, :end_fragment, :start_fragment, :blob
+      attr_reader :message_id, :fragment_id, :end_fragment, :start_fragment, :blob
 
       # Returns the raw PSRP message bytes ready for transfer to Windows inside a
       # WinRM message.
       # @return [Array<Byte>] Unencoded raw byte array of the PSRP message.
       def bytes
         [
-          int64be(object_id),
+          int64be(message_id),
           int64be(fragment_id),
           end_start_fragment,
           int16be(blob.length),

--- a/lib/winrm/psrp/message_defragmenter.rb
+++ b/lib/winrm/psrp/message_defragmenter.rb
@@ -26,13 +26,13 @@ module WinRM
       def defragment(base64_bytes)
         fragment = fragment_from(Base64.decode64(base64_bytes))
 
-        @messages[fragment.object_id] ||= []
-        @messages[fragment.object_id].push fragment
+        @messages[fragment.message_id] ||= []
+        @messages[fragment.message_id].push fragment
 
         # rubocop:disable Style/GuardClause
         if fragment.end_fragment
           blob = []
-          @messages.delete(fragment.object_id).each { |frag| blob += frag.blob }
+          @messages.delete(fragment.message_id).each { |frag| blob += frag.blob }
           return message_from(blob.pack('C*'))
         end
         # rubocop:enable Style/GuardClause

--- a/lib/winrm/psrp/message_fragmenter.rb
+++ b/lib/winrm/psrp/message_fragmenter.rb
@@ -22,15 +22,15 @@ module WinRM
       DEFAULT_BLOB_LENGTH = 32_768
 
       def initialize(max_blob_length = DEFAULT_BLOB_LENGTH)
-        @object_id = 0
+        @message_id = 0
         @max_blob_length = max_blob_length || DEFAULT_BLOB_LENGTH
       end
 
-      attr_reader :object_id
+      attr_reader :message_id
       attr_accessor :max_blob_length
 
       def fragment(message)
-        @object_id += 1
+        @message_id += 1
         message_bytes = message.bytes
         bytes_fragmented = 0
         fragment_id = 0
@@ -40,7 +40,7 @@ module WinRM
           last_byte = bytes_fragmented + max_blob_length
           last_byte = message_bytes.length if last_byte > message_bytes.length
           fragment = Fragment.new(
-            object_id,
+            message_id,
             message.bytes[bytes_fragmented..last_byte - 1],
             fragment_id,
             bytes_fragmented.zero?,


### PR DESCRIPTION
Ruby 3.4 prints the following message when redefining object_id:

```
warning: redefining 'object_id' may cause serious problems
```

According to fragment.rb, winrm’s object_id is the ID of the message, so let’s rename it to message_id.

message_id was not used before, and no calls to object_id referred to Ruby’s, so I’ve naively replaced all occurrences of object_id by message_id.

I do not have a Windows machine to test, but this change should be safe unless external calling code use these methods.