### PR TITLE
Add deprecation shim for the logging-gem logger API

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,8 @@ If a consuming application uses its own logger that complies to the stdlib `Logg
 conn.logger = my_logger
 ```
 
+Upgrading from the `logging` gem: the one `logging`-specific call that used to work, `conn.logger.add_appenders(...)`, is still accepted but logs a deprecation warning and has no effect. Configure the stdlib logger directly (or inject your own) instead.
+
 ## Troubleshooting
 You may have some errors like ```WinRM::WinRMAuthorizationError```. See [this post](http://www.hurryupandwait.io/blog/understanding-and-troubleshooting-winrm-connection-and-authentication-a-thrill-seekers-guide-to-adventure) for tips and troubleshooting steps related to winrm connection and authentication issues.
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 # WinRM Gem Changelog
 
 # Unreleased
-* Replace the unmaintained `logging` gem (which depends on `syslog`, no longer a default gem in modern Ruby) with the Ruby standard library `Logger`. Breaking change: `Connection#logger` is now a stdlib `Logger`, so `logging`-specific calls like `add_appenders` no longer work; injecting a custom logger via `conn.logger=` is unchanged. `WINRM_LOG` is still honored.
+* Replace the unmaintained `logging` gem (which depends on `syslog`, no longer a default gem in modern Ruby) with the Ruby standard library `Logger`. `Connection#logger` is now a stdlib `Logger` subclass, so the standard logging API is unchanged and injecting a custom logger via `conn.logger=` still works. `logging`-specific calls like `add_appenders` are still accepted but emit a deprecation warning; `WINRM_LOG` is still honored.
 
 # 2.3.9
 * Fix snakecase `NoMethodError` by @ripa1995 in https://github.com/WinRb/WinRM/pull/347

--- a/lib/winrm.rb
+++ b/lib/winrm.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 require 'logger'
+require_relative 'winrm/compat_logger'
 require_relative 'winrm/version'
 require_relative 'winrm/connection'
 require_relative 'winrm/exceptions'

--- a/lib/winrm/compat_logger.rb
+++ b/lib/winrm/compat_logger.rb
@@ -23,7 +23,7 @@ module WinRM
 
     def deprecate_appenders
       @appenders_deprecated = true
-      warn '[DEPRECATION] WinRM: `logger.add_appenders` is deprecated and has no effect. ' \
+      Kernel.warn '[DEPRECATION] WinRM: `logger.add_appenders` is deprecated and has no effect. ' \
            'Configure the stdlib logger directly or inject your own via `Connection#logger=`.'
     end
   end

--- a/lib/winrm/compat_logger.rb
+++ b/lib/winrm/compat_logger.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'logger'
+
+module WinRM
+  # Backwards-compatible default for `Connection#logger`.
+  #
+  # WinRM used to expose a `logging`-gem logger here; it now exposes a plain
+  # stdlib {Logger} instead. This subclass keeps the small `logging`-specific
+  # API callers actually used (`add_appenders`) working while emitting a
+  # deprecation warning, so existing code keeps running instead of breaking
+  # on upgrade. Everything else is exactly stdlib `Logger` behavior.
+  class CompatLogger < ::Logger
+    # Accepts `logging`-gem-style appenders for backwards compatibility.
+    # Stdlib loggers write to their log device, so appenders have no
+    # equivalent here and are ignored.
+    def add_appenders(*_appenders)
+      deprecate_appenders unless @appenders_deprecated
+      nil
+    end
+
+    private
+
+    def deprecate_appenders
+      @appenders_deprecated = true
+      warn '[DEPRECATION] WinRM: `logger.add_appenders` is deprecated and has no effect. ' \
+           'Configure the stdlib logger directly or inject your own via `Connection#logger=`.'
+    end
+  end
+end

--- a/lib/winrm/connection.rb
+++ b/lib/winrm/connection.rb
@@ -65,7 +65,7 @@ module WinRM
     end
 
     def configure_logger
-      @logger = Logger.new($stdout, progname: 'WinRM', level: WinRM.default_log_level)
+      @logger = WinRM::CompatLogger.new($stdout, progname: 'WinRM', level: WinRM.default_log_level)
     end
 
     def shell_factory

--- a/tests/spec/compat_logger_spec.rb
+++ b/tests/spec/compat_logger_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'stringio'
+require 'winrm'
+require 'winrm/compat_logger'
+
+describe WinRM::CompatLogger do
+  let(:io) { StringIO.new }
+  let(:logger) { WinRM::CompatLogger.new(io) }
+
+  it 'is a stdlib Logger' do
+    expect(logger).to be_a(::Logger)
+  end
+
+  it 'logs through the standard API' do
+    logger.level = :debug
+    logger.info('hello')
+    expect(io.string).to include('hello')
+  end
+
+  it 'accepts add_appenders with a deprecation warning instead of raising' do
+    expect { logger.add_appenders(:stdout) }.not_to raise_error
+    expect { WinRM::CompatLogger.new(io).add_appenders(:stdout) }
+      .to output(/DEPRECATION.*add_appenders/).to_stderr
+  end
+
+  it 'warns only once per instance' do
+    expect { logger.add_appenders(:stdout) }.to output(/DEPRECATION/).to_stderr
+    expect { logger.add_appenders(:stdout) }.not_to output.to_stderr
+  end
+end


### PR DESCRIPTION
#358 replaced the unmaintained `logging` gem with stdlib `Logger`, which is a breaking change for anyone calling `logging`-specific methods like `add_appenders` on `Connection#logger`.

This keeps it non-breaking:

- New `WinRM::CompatLogger < ::Logger` used as the default `Connection#logger`. It is a real stdlib `Logger`, so `is_a?(Logger)` checks and the whole standard API behave exactly as before.
- `add_appenders` is still accepted but emits a one-time-per-instance deprecation warning and has no effect (stdlib loggers write to their log device; appenders have no equivalent).
- `conn.logger=` injection and `WINRM_LOG` are untouched.
- Changelog entry softened and README documents the migration path.
- New `tests/spec/compat_logger_spec.rb` covers the shim.

With this in place the pending release no longer needs a major version bump for the logger change.