### PR TITLE
Scope CI push trigger to default branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,9 @@
 name: Ruby
 
 on:
-  - push
-  - pull_request
+  push:
+    branches: [main]
+  pull_request:
 
 permissions:
   contents: read # checkout only, nothing else


### PR DESCRIPTION
The workflow ran on every `push` as well as `pull_request`, so pushes to PR branches ran the suite twice. Scope `push` to the default branch (`main`) only; `pull_request` stays unscoped.

No other triggers or jobs changed.